### PR TITLE
Fjerner dep.man for org.jvnet.jaxb2_commons:jaxb2-basics-runtime

### DIFF
--- a/felles/pom.xml
+++ b/felles/pom.xml
@@ -86,12 +86,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Kommer fra felles-tjenestebeskrivelser på github -->
-            <dependency>
-                <groupId>org.jvnet.jaxb2_commons</groupId>
-                <artifactId>jaxb2-basics-runtime</artifactId>
-                <version>0.9.5</version>
-            </dependency>
 
 			<dependency>
 				<!-- er ikke i resteasy-bom, så må defineres separat -->

--- a/integrasjon/behandlesak-klient/pom.xml
+++ b/integrasjon/behandlesak-klient/pom.xml
@@ -26,10 +26,5 @@
             <groupId>no.nav.tjenestespesifikasjoner</groupId>
             <artifactId>nav-fim-sak-v1-tjenestespesifikasjon</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jvnet.jaxb2_commons</groupId>
-            <artifactId>jaxb2-basics-runtime</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/integrasjon/pom.xml
+++ b/integrasjon/pom.xml
@@ -350,13 +350,6 @@
                 <version>${ibmmq.version}</version>
             </dependency>
 
-            <!-- test avhengigheter -->
-            <dependency>
-                <groupId>org.jvnet.jaxb2_commons</groupId>
-                <artifactId>jaxb2-basics-runtime</artifactId>
-                <version>1.11.1</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
... siden den nå er konvergert til en felles versjon i felles-tjenestebeskrivelser

@IverFraNav Da bør du også kunne rydde opp endringene du gjorde i fp-fordel