### PR TITLE
FIX fjerner inntekt-klient

### DIFF
--- a/integrasjon/bom/pom.xml
+++ b/integrasjon/bom/pom.xml
@@ -86,10 +86,15 @@
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>arbeidsforhold-klient</artifactId>
         </dependency>
+        
+        <!-- Fjernet fra BOM, bruk heller REST klient (aordningen-inntektinformasjon) -->
+        <!--
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>inntekt-klient</artifactId>
         </dependency>
+        -->
+        
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>kodeverk-klient</artifactId>


### PR DESCRIPTION
inntekt-klient er gammel WS tjeneste for inntektskomponenten. Bruk heller aordninge inntektsinformasjon REST klient (spesifiser selv denne i egen applikasjon hvis trengs).