### PR TITLE
FIX felles testklasse for å støtte lookup. Den gamle kaster exception

### DIFF
--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/cdi/UnitTestLookupInstanceImpl.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/cdi/UnitTestLookupInstanceImpl.java
@@ -1,0 +1,60 @@
+package no.nav.vedtak.felles.testutilities.cdi;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
+
+public class UnitTestLookupInstanceImpl<T> implements Instance<T> {
+
+    T verdi;
+
+    public UnitTestLookupInstanceImpl(T verdi) {
+        this.verdi = verdi;
+    }
+
+    @Override
+    public T get() {
+        return verdi;
+    }
+
+    //Metodene her kan implementeres etter behov
+
+    @Override
+    public Instance<T> select(Annotation... annotations) {
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <U extends T> Instance<U> select(Class<U> aClass, Annotation... annotations) {
+        return (Instance<U>) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <U extends T> Instance<U> select(TypeLiteral<U> typeLiteral, Annotation... annotations) {
+        return (Instance<U>) this;
+    }
+
+    @Override
+    public boolean isUnsatisfied() {
+        return false;
+    }
+
+    @Override
+    public boolean isAmbiguous() {
+        return false;
+    }
+
+    @Override
+    public void destroy(T t) {
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return Arrays.asList(get()).iterator();
+    }
+}


### PR DESCRIPTION
Unngå at den klassen du skrev for å teste Annotasjon . Lookup ikke formerer seg uhemmet.
Har beholdt den gamle ettersom den er i bruk et par steder.
Hvordan kan vi få sendt med en mengde implementasjoner ? (tjenesteES, tjenesteFP, tjenesterSVP)