### PR TITLE
FIX skiller ut env properites fra generell PropertiesKonfigVerdiProvi…

### DIFF
--- a/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
@@ -1,0 +1,26 @@
+package no.nav.vedtak.konfig;
+
+import java.util.Properties;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/** Henter properties fra {@link System#getProperties}. */
+@ApplicationScoped
+public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvider {
+    
+    public EnvPropertiesKonfigVerdiProvider() {
+        super(getEnv());
+    }
+
+    private static Properties getEnv() {
+        var p = new Properties();
+        p.putAll(System.getenv());
+        return p;
+    }
+
+    @Override
+    public int getPrioritet() {
+        // Et hakk lavere prioritet enn SystemPropertiesKonfigVerdiProvider
+        return 11; // NOSONAR
+    }
+}

--- a/felles/util/src/main/java/no/nav/vedtak/konfig/PropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/PropertiesKonfigVerdiProvider.java
@@ -18,7 +18,7 @@ public abstract class PropertiesKonfigVerdiProvider implements KonfigVerdiProvid
 
     @Override
     public <V> V getVerdi(String key, KonfigVerdi.Converter<V> converter) {
-        return converter.tilVerdi(PropertyUtil.getProperty(key));
+        return converter.tilVerdi((String) props.get(key));
     }
 
     @Override
@@ -47,5 +47,5 @@ public abstract class PropertiesKonfigVerdiProvider implements KonfigVerdiProvid
                         ));
         return map;
     }
-
+    
 }


### PR DESCRIPTION
…der slik at det er mulig å sette disse uten å skrive over system properties, fra en ny provider