### PR TITLE
rydd i prioriteter for konfig providers

### DIFF
--- a/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
@@ -7,6 +7,7 @@ import javax.enterprise.context.ApplicationScoped;
 /** Henter properties fra {@link System#getProperties}. */
 @ApplicationScoped
 public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvider {
+    public static final int PRIORITET = SystemPropertiesKonfigVerdiProvider.PRIORITET + 1;
     
     public EnvPropertiesKonfigVerdiProvider() {
         super(getEnv());
@@ -21,6 +22,6 @@ public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvi
     @Override
     public int getPrioritet() {
         // Et hakk lavere prioritet enn SystemPropertiesKonfigVerdiProvider
-        return 11; // NOSONAR
+        return PRIORITET;
     }
 }

--- a/felles/util/src/main/java/no/nav/vedtak/konfig/PropertyFileKonfigProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/PropertyFileKonfigProvider.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 @ApplicationScoped
 public class PropertyFileKonfigProvider extends PropertiesKonfigVerdiProvider {
 
-    private static final int PRIORITET = Integer.MAX_VALUE;
+    private static final int PRIORITET = EnvPropertiesKonfigVerdiProvider.PRIORITET + 1;
     private static final String LOCAL = "local";
     private static final String NAIS_CLUSTER_NAME = "NAIS_CLUSTER_NAME";
     private static final String NAIS_NAMESPACE_NAME = "NAIS_NAMESPACE_NAME";

--- a/felles/util/src/main/java/no/nav/vedtak/konfig/SystemPropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/SystemPropertiesKonfigVerdiProvider.java
@@ -5,6 +5,7 @@ import javax.enterprise.context.ApplicationScoped;
 /** Henter properties fra {@link System#getProperties}. */
 @ApplicationScoped
 public class SystemPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvider {
+    public static final int PRIORITET = Integer.MIN_VALUE;
     
     public SystemPropertiesKonfigVerdiProvider() {
         super(System.getProperties());
@@ -12,6 +13,6 @@ public class SystemPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiPr
 
     @Override
     public int getPrioritet() {
-        return 10; // NOSONAR
+        return PRIORITET;
     }
 }


### PR DESCRIPTION
1, System properties
2. Env properties
3. file properties
4. Alt annet bruker måtte finne på selv, f.eks DB

Dette muliggjør gradvis utfasing av DB-provider i f.eks fpfordel, slik at hundrevis av linjer kode kan slettes. 