### PR TITLE
FIX retry antatt transiente feil, feil hardt for andre feil

### DIFF
--- a/prosesstask/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
+++ b/prosesstask/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
@@ -125,7 +125,7 @@ public class RunTaskFeilOgStatusEventHåndterer {
                                             int failureAttempt) {
 
         // Prøv på nytt hvis kjent exception og feilhåndteringsalgoritmen tilsier nytt forsøk. Ellers fail-fast
-        if (feilhåndteringExceptions(e)) {
+        if (feilhåndteringExceptions(e) || (e.getCause() != null && feilhåndteringExceptions(e.getCause()))) {
             return feilhåndteringsalgoritme.skalKjørePåNytt(taskType.tilProsessTaskTypeInfo(), failureAttempt, e);
         }
         return false;

--- a/prosesstask/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
+++ b/prosesstask/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
@@ -124,17 +124,15 @@ public class RunTaskFeilOgStatusEventHåndterer {
     private boolean sjekkOmSkalKjøresPåNytt(Exception e, ProsessTaskType taskType, ProsessTaskFeilhåndteringAlgoritme feilhåndteringsalgoritme,
                                             int failureAttempt) {
 
-        if (e.getCause() != null && feilhåndteringExceptions(e.getCause())) {
-            return false;
-        } else if (e.getCause() == null && feilhåndteringExceptions(e)) {
-            return false;
-        } else {
+        // Prøv på nytt hvis kjent exception og feilhåndteringsalgoritmen tilsier nytt forsøk. Ellers fail-fast
+        if (feilhåndteringExceptions(e)) {
             return feilhåndteringsalgoritme.skalKjørePåNytt(taskType.tilProsessTaskTypeInfo(), failureAttempt, e);
         }
+        return false;
     }
 
     private boolean feilhåndteringExceptions(Throwable e) {
-        return (FEILHÅNDTERING_EXCEPTIONS.stream().noneMatch(fatal -> fatal.isAssignableFrom(e.getClass())));
+        return (FEILHÅNDTERING_EXCEPTIONS.stream().anyMatch(fatal -> fatal.isAssignableFrom(e.getClass())));
     }
 
     protected static String getFeiltekstOgLoggHvisFørstegang(ProsessTaskEntitet pte, Feil feil, Throwable t) {


### PR DESCRIPTION
Før ville denne algoritmen retrye dobbelwrapped exceptions inntil MAX ganger, men ikke retrye Integrasjon (SoapFault()).
Dobbel negasjon gjort litt enklere  