### PR TITLE
harVerdi sjekker også uppercase og _ varianten

### DIFF
--- a/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
@@ -10,6 +10,7 @@ import javax.enterprise.context.ApplicationScoped;
 import no.nav.vedtak.konfig.KonfigVerdi.Converter;
 
 @ApplicationScoped
+
 public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvider {
 
     public static final int PRIORITET = SystemPropertiesKonfigVerdiProvider.PRIORITET + 1;
@@ -26,7 +27,7 @@ public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvi
 
     @Override
     public boolean harVerdi(String key) {
-        return super.harVerdi(key) || super.harVerdi(upper(key)) || super.harVerdi(endpointUrlKey(key));
+        return super.harVerdi(key) || super.harVerdi(upper(key));
     }
 
     private static String upper(String key) {

--- a/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
+++ b/felles/util/src/main/java/no/nav/vedtak/konfig/EnvPropertiesKonfigVerdiProvider.java
@@ -9,7 +9,6 @@ import javax.enterprise.context.ApplicationScoped;
 
 import no.nav.vedtak.konfig.KonfigVerdi.Converter;
 
-/** Henter properties fra {@link System#getProperties}. */
 @ApplicationScoped
 public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvider {
 
@@ -22,7 +21,16 @@ public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvi
     @Override
     public <V> V getVerdi(String key, Converter<V> converter) {
         return Optional.ofNullable(super.getVerdi(key, converter))
-                .orElse(super.getVerdi(key.toUpperCase().replace('.', '_'), converter));
+                .orElse(super.getVerdi(upper(key), converter));
+    }
+
+    @Override
+    public boolean harVerdi(String key) {
+        return super.harVerdi(key) || super.harVerdi(upper(key)) || super.harVerdi(endpointUrlKey(key));
+    }
+
+    private static String upper(String key) {
+        return key.toUpperCase().replace('.', '_');
     }
 
     private static Properties getEnv() {
@@ -33,7 +41,6 @@ public class EnvPropertiesKonfigVerdiProvider extends PropertiesKonfigVerdiProvi
 
     @Override
     public int getPrioritet() {
-        // Et hakk lavere prioritet enn SystemPropertiesKonfigVerdiProvider
         return PRIORITET;
     }
 }


### PR DESCRIPTION
**harVerdi** er egentlig overflødig, kunne og burde vært implementert som `getVerdi != null`, men tør ikke ta mer i dette korthuset enn nødvendig. 