### PR TITLE
FIX revert to working httpclient, add dep to infotrygd-grunnlag

### DIFF
--- a/felles/pom.xml
+++ b/felles/pom.xml
@@ -206,7 +206,7 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.11</version>
+				<version>4.5.10</version>
 				<exclusions>
 					<exclusion>
 						<groupId>commons-logging</groupId>

--- a/integrasjon/pom.xml
+++ b/integrasjon/pom.xml
@@ -191,6 +191,11 @@
 			</dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
+                <artifactId>infotrygd-grunnlag-klient</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
                 <artifactId>infotrygd-saker-klient</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Dependabot foreslo httpclient 4.5.11 - men den virker dårlig med rest til ikke-fp fra fordel og abonnent. Klager på ssh/certificate/domain-name
4.5.10 virker - så slipper alle apps overstyre versjonen i felles.
+ Uteglemt dependency for trex-grunnlag