### PR TITLE
Streng som input til beskyttet ressurs

### DIFF
--- a/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAttributtSamling.java
+++ b/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAttributtSamling.java
@@ -7,7 +7,7 @@ public class AbacAttributtSamling {
     private final AbacIdToken idToken;
     private final AbacDataAttributter dataAttributter = AbacDataAttributter.opprett();
     private BeskyttetRessursActionAttributt actionType;
-    private BeskyttetRessursResourceAttributt resource;
+    private String resource;
     private String action;
 
     private AbacAttributtSamling(AbacIdToken idToken) {
@@ -60,12 +60,12 @@ public class AbacAttributtSamling {
         return actionType;
     }
 
-    public AbacAttributtSamling setResource(BeskyttetRessursResourceAttributt resource) {
+    public AbacAttributtSamling setResource(String resource) {
         this.resource = resource;
         return this;
     }
 
-    public BeskyttetRessursResourceAttributt getResource() {
+    public String getResource() {
         return resource;
     }
 

--- a/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessurs.java
+++ b/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessurs.java
@@ -17,7 +17,9 @@ import javax.interceptor.InterceptorBinding;
 public @interface BeskyttetRessurs {
     @Nonbinding BeskyttetRessursActionAttributt action();
 
-    @Nonbinding BeskyttetRessursResourceAttributt ressurs();
+    @Nonbinding @Deprecated BeskyttetRessursResourceAttributt ressurs() default BeskyttetRessursResourceAttributt.DUMMY;
+
+    @Nonbinding String resource() default "";
 
     /**
      * Sett til false for å unngå at det logges til sporingslogg ved tilgang. Det skal bare gjøres for tilfeller som ikke håndterer personopplysninger.

--- a/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/PepImpl.java
+++ b/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/abac/PepImpl.java
@@ -16,6 +16,8 @@ import no.nav.vedtak.sikkerhet.context.SubjectHandler;
 @Default
 @ApplicationScoped
 public class PepImpl implements Pep {
+    private final static String PIP = "pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker";
+
 
     private PdpKlient pdpKlient;
     private PdpRequestBuilder pdpRequestBuilder;
@@ -50,7 +52,7 @@ public class PepImpl implements Pep {
     public Tilgangsbeslutning vurderTilgang(AbacAttributtSamling attributter) {
         PdpRequest pdpRequest = pdpRequestBuilder.lagPdpRequest(attributter);
 
-        if (BeskyttetRessursResourceAttributt.PIP.equals(attributter.getResource())) {
+        if (PIP.equals(attributter.getResource())) {
             return vurderTilgangTilPipTjeneste(pdpRequest, attributter);
         } else {
             return pdpKlient.forespørTilgang(pdpRequest);

--- a/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessursInterceptorTest.java
+++ b/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessursInterceptorTest.java
@@ -34,7 +34,7 @@ public class BeskyttetRessursInterceptorTest {
             PdpRequest pdpRequest = new PdpRequest();
             pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_PERSON_AKTOERID_RESOURCE, Collections.singleton(aktør1.getAktørId()));
             pdpRequest.put(NavAbacCommonAttributter.XACML10_ACTION_ACTION_ID, attributter.getActionType().getEksternKode());
-            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource().getEksternKode());
+            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource());
             pdpRequest.put(PdpKlient.ENVIRONMENT_AUTH_TOKEN, attributter.getIdToken());
             return new Tilgangsbeslutning(
                 AbacResultat.GODKJENT,
@@ -55,7 +55,7 @@ public class BeskyttetRessursInterceptorTest {
             PdpRequest pdpRequest = new PdpRequest();
             pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_PERSON_AKTOERID_RESOURCE, (Collections.singleton(aktør1.getAktørId())));
             pdpRequest.put(NavAbacCommonAttributter.XACML10_ACTION_ACTION_ID, attributter.getActionType().getEksternKode());
-            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource().getEksternKode());
+            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource());
             pdpRequest.put(PdpKlient.ENVIRONMENT_AUTH_TOKEN, attributter.getIdToken());
             return new Tilgangsbeslutning(
                 AbacResultat.GODKJENT,
@@ -77,7 +77,7 @@ public class BeskyttetRessursInterceptorTest {
             PdpRequest pdpRequest = new PdpRequest();
             pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_PERSON_FNR, (Collections.singleton(aktør1.getAktørId())));
             pdpRequest.put(NavAbacCommonAttributter.XACML10_ACTION_ACTION_ID, attributter.getActionType().getEksternKode());
-            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource().getEksternKode());
+            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource());
             pdpRequest.put(PdpKlient.ENVIRONMENT_AUTH_TOKEN, attributter.getIdToken());
             return new Tilgangsbeslutning(
                 AbacResultat.GODKJENT,
@@ -98,7 +98,7 @@ public class BeskyttetRessursInterceptorTest {
             PdpRequest pdpRequest = new PdpRequest();
             pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_PERSON_FNR, (Collections.singleton(aktør1.getAktørId())));
             pdpRequest.put(NavAbacCommonAttributter.XACML10_ACTION_ACTION_ID, attributter.getActionType().getEksternKode());
-            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource().getEksternKode());
+            pdpRequest.put(NavAbacCommonAttributter.RESOURCE_FELLES_RESOURCE_TYPE, attributter.getResource());
             pdpRequest.put(PdpKlient.ENVIRONMENT_AUTH_TOKEN, attributter.getIdToken());
             return new Tilgangsbeslutning(
                 AbacResultat.AVSLÅTT_KODE_6,
@@ -119,10 +119,11 @@ public class BeskyttetRessursInterceptorTest {
             "action=/foo/aktoer_in abac_action=create abac_resource_type=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker aktorId=00000000000 decision=Deny");
     }
 
+
     @Path("foo")
     public static class RestClass {
 
-        @BeskyttetRessurs(action = BeskyttetRessursActionAttributt.CREATE, ressurs = BeskyttetRessursResourceAttributt.PIP)
+        @BeskyttetRessurs(action = BeskyttetRessursActionAttributt.CREATE, resource = "pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker")
         @Path("aktoer_in")
         public void aktoerIn(@SuppressWarnings("unused") AktørDto param) {
 

--- a/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
+++ b/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
@@ -15,6 +15,7 @@ import no.nav.vedtak.sikkerhet.context.SubjectHandlerUtils;
 
 public class PepImplTest {
 
+
     private PepImpl pep;
     private PdpKlient pdpKlientMock;
 
@@ -34,7 +35,7 @@ public class PepImplTest {
     public void skal_gi_tilgang_til_srvpdp_for_piptjeneste() {
         SubjectHandlerUtils.setInternBruker("srvpdp");
         AbacAttributtSamling attributter = AbacAttributtSamling.medJwtToken("dummy")
-                .setResource(BeskyttetRessursResourceAttributt.PIP)
+                .setResource(BeskyttetRessursResourceAttributt.PIP.getEksternKode())
                 .setAction("READ");
 
         Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
@@ -46,7 +47,7 @@ public class PepImplTest {
     public void skal_nekte_tilgang_til_saksbehandler_for_piptjeneste() {
         SubjectHandlerUtils.setInternBruker("z142443");
         AbacAttributtSamling attributter = AbacAttributtSamling.medJwtToken("dummy")
-                .setResource(BeskyttetRessursResourceAttributt.PIP)
+                .setResource(BeskyttetRessursResourceAttributt.PIP.getEksternKode())
                 .setAction("READ");
 
         Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
@@ -58,7 +59,7 @@ public class PepImplTest {
     public void skal_kalle_pdp_for_annet_enn_pip_tjenester(){
         SubjectHandlerUtils.setInternBruker("z142443");
         AbacAttributtSamling attributter = AbacAttributtSamling.medJwtToken("dummy")
-                .setResource(BeskyttetRessursResourceAttributt.FAGSAK)
+                .setResource(BeskyttetRessursResourceAttributt.FAGSAK.getEksternKode())
                 .setAction("READ");
 
         @SuppressWarnings("unused")


### PR DESCRIPTION
Utvider BeskyttetRessurs med mulighet til å angi ressurser som streng for å kunne benytte verdier utover de angitt i BeskyttetRessursResourceAttributt. Deprecated BeskyttetRessursResourceAttributt som ressurs.