### PR TITLE
ABAC: Bytter pep_id fra systembruker til app navn.

### DIFF
--- a/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImpl.java
+++ b/felles/sikkerhet/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImpl.java
@@ -26,13 +26,13 @@ import no.nav.vedtak.sikkerhet.pdp.xacml.Obligation;
 import no.nav.vedtak.sikkerhet.pdp.xacml.XacmlAttributeSet;
 import no.nav.vedtak.sikkerhet.pdp.xacml.XacmlRequestBuilder;
 import no.nav.vedtak.sikkerhet.pdp.xacml.XacmlResponseWrapper;
+import no.nav.vedtak.util.env.Environment;
 
 @ApplicationScoped
 public class PdpKlientImpl implements PdpKlient {
 
     private static final Logger logger = LoggerFactory.getLogger(PdpKlientImpl.class);
     private XacmlRequestBuilderTjeneste xamlRequestBuilderTjeneste;
-    private String pepId;
 
     private PdpConsumer pdpConsumer;
 
@@ -41,11 +41,9 @@ public class PdpKlientImpl implements PdpKlient {
     }
 
     @Inject
-    public PdpKlientImpl(PdpConsumer pdpConsumer, XacmlRequestBuilderTjeneste xamlRequestBuilderTjeneste,
-                         @KonfigVerdi("systembruker.username") String pepId) {
+    public PdpKlientImpl(PdpConsumer pdpConsumer, XacmlRequestBuilderTjeneste xamlRequestBuilderTjeneste) {
         this.pdpConsumer = pdpConsumer;
         this.xamlRequestBuilderTjeneste = xamlRequestBuilderTjeneste;
-        this.pepId = pepId;
     }
 
     @Override
@@ -60,7 +58,7 @@ public class PdpKlientImpl implements PdpKlient {
 
     void leggPåTokenInformasjon(XacmlRequestBuilder xacmlBuilder, PdpRequest pdpRequest) {
         XacmlAttributeSet environmentAttributeSet = new XacmlAttributeSet();
-        environmentAttributeSet.addAttribute(no.nav.vedtak.sikkerhet.abac.NavAbacCommonAttributter.ENVIRONMENT_FELLES_PEP_ID, pepId);
+        environmentAttributeSet.addAttribute(no.nav.vedtak.sikkerhet.abac.NavAbacCommonAttributter.ENVIRONMENT_FELLES_PEP_ID, getPepId());
         AbacIdToken idToken = (AbacIdToken) pdpRequest.get(ENVIRONMENT_AUTH_TOKEN);
         if (idToken.erOidcToken()) {
             environmentAttributeSet.addAttribute(no.nav.vedtak.sikkerhet.abac.NavAbacCommonAttributter.ENVIRONMENT_FELLES_OIDC_TOKEN_BODY, JwtUtil.getJwtBody(idToken.getToken()));
@@ -124,5 +122,9 @@ public class PdpKlientImpl implements PdpKlient {
         if (!obligations.isEmpty()) {
             throw PdpFeil.FACTORY.ukjentObligationsFeil(obligations).toException();
         }
+    }
+
+    private static String getPepId() {
+        return Environment.current().getProperty("NAIS_APP_NAME", "local-app");
     }
 }

--- a/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImplTest.java
+++ b/felles/sikkerhet/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImplTest.java
@@ -41,7 +41,6 @@ import no.nav.vedtak.sikkerhet.pdp.xacml.XacmlResponseWrapper;
 public class PdpKlientImplTest {
 
     public static final String JWT_TOKEN = "eyAidHlwIjogIkpXVCIsICJraWQiOiAiU0gxSWVSU2sxT1VGSDNzd1orRXVVcTE5VHZRPSIsICJhbGciOiAiUlMyNTYiIH0.eyAiYXRfaGFzaCI6ICIyb2c1RGk5ZW9LeFhOa3VPd0dvVUdBIiwgInN1YiI6ICJzMTQyNDQzIiwgImF1ZGl0VHJhY2tpbmdJZCI6ICI1NTM0ZmQ4ZS03MmE2LTRhMWQtOWU5YS1iZmEzYThhMTljMDUtNjE2NjA2NyIsICJpc3MiOiAiaHR0cHM6Ly9pc3NvLXQuYWRlby5ubzo0NDMvaXNzby9vYXV0aDIiLCAidG9rZW5OYW1lIjogImlkX3Rva2VuIiwgImF1ZCI6ICJPSURDIiwgImNfaGFzaCI6ICJiVWYzcU5CN3dTdi0wVlN0bjhXLURnIiwgIm9yZy5mb3JnZXJvY2sub3BlbmlkY29ubmVjdC5vcHMiOiAiMTdhOGZiMzYtMGI0Ny00YzRkLWE4YWYtZWM4Nzc3Y2MyZmIyIiwgImF6cCI6ICJPSURDIiwgImF1dGhfdGltZSI6IDE0OTgwMzk5MTQsICJyZWFsbSI6ICIvIiwgImV4cCI6IDE0OTgwNDM1MTUsICJ0b2tlblR5cGUiOiAiSldUVG9rZW4iLCAiaWF0IjogMTQ5ODAzOTkxNSB9.S2DKQweQWZIfjaAT2UP9_dxrK5zqpXj8IgtjDLt5PVfLYfZqpWGaX-ckXG0GlztDVBlRK4ylmIYacTmEAUV_bRa_qWKRNxF83SlQRgHDSiE82SGv5WHOGEcAxf2w_d50XsgA2KDBCyv0bFIp9bCiKzP11uWPW0v4uIkyw2xVxMVPMCuiMUtYFh80sMDf9T4FuQcFd0LxoYcSFDEDlwCdRiF3ufw73qtMYBlNIMbTGHx-DZWkZV7CgukmCee79gwQIvGwdLrgaDrHFCJUDCbB1FFEaE3p3_BZbj0T54fCvL69aHyWm1zEd9Pys15yZdSh3oSSr4yVNIxhoF-nQ7gY-g;";
-    private static final String PEP_ID = "pepId";
     private PdpKlient pdpKlient;
     private PdpConsumer pdpConsumerMock;
     private XacmlRequestBuilderTjenesteImpl xamlRequestBuilderTjeneste;
@@ -50,7 +49,7 @@ public class PdpKlientImplTest {
     public void setUp() {
         pdpConsumerMock = mock(PdpConsumer.class);
         xamlRequestBuilderTjeneste = new XacmlRequestBuilderTjenesteImpl();
-        pdpKlient = new PdpKlientImpl(pdpConsumerMock, xamlRequestBuilderTjeneste, PEP_ID);
+        pdpKlient = new PdpKlientImpl(pdpConsumerMock, xamlRequestBuilderTjeneste);
     }
 
     @Test


### PR DESCRIPTION
PEP_ID brukes ikke i verken foreldrepenger eller k9 sine policies.
Team duplo ønsker å ta det i bruk slikt at switching mellom forskjellige ABAC policy tre er enklere.
Det føles at application navn er litt bedre egnet til dette enn systembruker navn. 