### PR TITLE
TFP-3397 ereg / org - rs klient for basisdata og brevbruk

### DIFF
--- a/integrasjon/ereg-klient/README.md
+++ b/integrasjon/ereg-klient/README.md
@@ -1,0 +1,15 @@
+# Organisasjon klient
+
+Modulen integrerer mot NAVs Enhetsregister. Tjenesten tilbyr funksjoner for å finne og hente ut informasjon og organisasjoner.
+
+## Hensikten
+
+Finne og hente organisasjoner i eksternt system.
+
+## Brukes av
+
+Modulen brukes av Vedtaksløsningen (modul organisasjon i vl-foreldrepenger/stottetjenester) 
+
+## Integrasjoner
+* Dokumentasjon https://confluence.adeo.no/display/FEL/EREG+-+Tjeneste+REST+ereg.api
+* Swagger https://modapp-q1.adeo.no/ereg/api/swagger-ui.html#/

--- a/integrasjon/ereg-klient/pom.xml
+++ b/integrasjon/ereg-klient/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
+        <artifactId>felles-integrasjon-pom</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ereg-klient</artifactId>
+    <packaging>jar</packaging>
+    <name>Felles :: Integrasjonsendepunkt - ereg-klient</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
+            <artifactId>felles-integrasjon-rest-klient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/AdresseEReg.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/AdresseEReg.java
@@ -1,0 +1,64 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class AdresseEReg {
+
+    @JsonProperty("adresselinje1")
+    private String adresselinje1;
+    @JsonProperty("adresselinje2")
+    private String adresselinje2;
+    @JsonProperty("adresselinje3")
+    private String adresselinje3;
+    @JsonProperty("kommunenummer")
+    private String kommunenummer;
+    @JsonProperty("landkode")
+    private String landkode;
+    @JsonProperty("postnummer")
+    private String postnummer;
+    @JsonProperty("poststed")
+    private String poststed;
+
+
+    public String getAdresselinje1() {
+        return adresselinje1;
+    }
+
+    public String getAdresselinje2() {
+        return adresselinje2;
+    }
+
+    public String getAdresselinje3() {
+        return adresselinje3;
+    }
+
+    public String getKommunenummer() {
+        return kommunenummer;
+    }
+
+    public String getLandkode() {
+        return landkode;
+    }
+
+    public String getPostnummer() {
+        return postnummer;
+    }
+
+    public String getPoststed() {
+        return poststed;
+    }
+
+    @Override
+    public String toString() {
+        return "Forretningsadresse{" +
+                "adresselinje1='" + adresselinje1 + '\'' +
+                '}';
+    }
+}
+

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonAdresse.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonAdresse.java
@@ -1,0 +1,117 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class OrganisasjonAdresse {
+
+    @JsonProperty("organisasjonsnummer")
+    private String organisasjonsnummer;
+    @JsonProperty("type")
+    private OrganisasjonstypeEReg type;
+    @JsonProperty("navn")
+    private Navn navn;
+    @JsonProperty("organisasjonDetaljer")
+    private OrganisasjonDetaljer organisasjonDetaljer;
+
+    public String getOrganisasjonsnummer() {
+        return organisasjonsnummer;
+    }
+
+    public OrganisasjonstypeEReg getType() {
+        return type;
+    }
+
+    public String getNavn() {
+        return navn != null ? navn.getNavn() : null;
+    }
+
+    public AdresseEReg getKorrespondanseadresse() {
+        return !getPostadresser().isEmpty() ? getPostadresser().get(0) : getForretningsadresser().get(0);
+    }
+
+    public List<AdresseEReg> getForretningsadresser() {
+        return organisasjonDetaljer != null ? organisasjonDetaljer.getForretningsadresser() : Collections.emptyList();
+    }
+
+    public List<AdresseEReg> getPostadresser() {
+        return organisasjonDetaljer != null ? organisasjonDetaljer.getPostadresser() : Collections.emptyList();
+    }
+
+    public LocalDate getRegistreringsdato() {
+        return organisasjonDetaljer != null && organisasjonDetaljer.getRegistreringsdato() != null
+            ? organisasjonDetaljer.getRegistreringsdato().toLocalDate() : null;
+    }
+
+    public LocalDate getOpphørsdato() {
+        return organisasjonDetaljer != null ? organisasjonDetaljer.getOpphoersdato() : null;
+    }
+
+
+    private static class Navn {
+
+        @JsonProperty("navnelinje1")
+        private String navnelinje1;
+        @JsonProperty("navnelinje2")
+        private String navnelinje2;
+        @JsonProperty("navnelinje3")
+        private String navnelinje3;
+        @JsonProperty("navnelinje4")
+        private String navnelinje4;
+        @JsonProperty("navnelinje5")
+        private String navnelinje5;
+
+        private Navn() {
+        }
+
+        private String getNavn() {
+            return Stream.of(navnelinje1, navnelinje2, navnelinje3, navnelinje4, navnelinje5)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(n -> !n.isEmpty())
+                .reduce("", (a, b) -> a + " " + b).trim();
+        }
+    }
+
+    private static class OrganisasjonDetaljer {
+
+        @JsonProperty("registreringsdato")
+        private LocalDateTime registreringsdato;
+        @JsonProperty("opphoersdato")
+        private LocalDate opphoersdato;
+        @JsonProperty("forretningsadresser")
+        private List<AdresseEReg> forretningsadresser;
+        @JsonProperty("postadresser")
+        private List<AdresseEReg> postadresser;
+
+        private LocalDateTime getRegistreringsdato() {
+            return registreringsdato;
+        }
+
+        private LocalDate getOpphoersdato() {
+            return opphoersdato;
+        }
+
+        private List<AdresseEReg> getForretningsadresser() {
+            return forretningsadresser != null ? forretningsadresser : Collections.emptyList();
+        }
+
+        private List<AdresseEReg> getPostadresser() {
+            return postadresser != null ? postadresser : Collections.emptyList();
+        }
+    }
+
+}
+

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonEReg.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonEReg.java
@@ -1,0 +1,121 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class OrganisasjonEReg {
+
+    @JsonProperty("organisasjonsnummer")
+    private String organisasjonsnummer;
+    @JsonProperty("type")
+    private OrganisasjonstypeEReg type;
+    @JsonProperty("navn")
+    private Navn navn;
+    @JsonProperty("organisasjonDetaljer")
+    private OrganisasjonDetaljer organisasjonDetaljer;
+    @JsonProperty("virksomhetDetaljer")
+    private VirksomhetDetaljer virksomhetDetaljer;
+
+    public String getOrganisasjonsnummer() {
+        return organisasjonsnummer;
+    }
+
+    public OrganisasjonstypeEReg getType() {
+        return type;
+    }
+
+    public String getNavn() {
+        return navn != null ? navn.getNavn() : null;
+    }
+
+    public LocalDate getRegistreringsdato() {
+        return organisasjonDetaljer != null && organisasjonDetaljer.getRegistreringsdato() != null
+            ? organisasjonDetaljer.getRegistreringsdato().toLocalDate() : null;
+    }
+
+    public LocalDate getOpphørsdato() {
+        return organisasjonDetaljer != null ? organisasjonDetaljer.getOpphoersdato() : null;
+    }
+
+    public LocalDate getOppstartsdato() {
+        return virksomhetDetaljer != null ? virksomhetDetaljer.getOppstartsdato() : null;
+    }
+
+    public LocalDate getNedleggelsesdato() {
+        return virksomhetDetaljer != null ? virksomhetDetaljer.getNedleggelsesdato() : null;
+    }
+
+
+    private static class Navn {
+
+        @JsonProperty("navnelinje1")
+        private String navnelinje1;
+        @JsonProperty("navnelinje2")
+        private String navnelinje2;
+        @JsonProperty("navnelinje3")
+        private String navnelinje3;
+        @JsonProperty("navnelinje4")
+        private String navnelinje4;
+        @JsonProperty("navnelinje5")
+        private String navnelinje5;
+
+        private Navn() {
+        }
+
+        private String getNavn() {
+            return Stream.of(navnelinje1, navnelinje2, navnelinje3, navnelinje4, navnelinje5)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(n -> !n.isEmpty())
+                .reduce("", (a, b) -> a + " " + b).trim();
+        }
+    }
+
+    private static class OrganisasjonDetaljer {
+
+        @JsonProperty("registreringsdato")
+        private LocalDateTime registreringsdato;
+        @JsonProperty("opphoersdato")
+        private LocalDate opphoersdato;
+
+        private LocalDateTime getRegistreringsdato() {
+            return registreringsdato;
+        }
+
+        private LocalDate getOpphoersdato() {
+            return opphoersdato;
+        }
+
+    }
+
+    private static class VirksomhetDetaljer {
+
+        @JsonProperty("oppstartsdato")
+        private LocalDate oppstartsdato;
+        @JsonProperty("nedleggelsesdato")
+        private LocalDate nedleggelsesdato;
+
+        private VirksomhetDetaljer() {
+        }
+
+        private LocalDate getOppstartsdato() {
+            return oppstartsdato;
+        }
+
+        private LocalDate getNedleggelsesdato() {
+            return nedleggelsesdato;
+        }
+    }
+
+}
+

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonRestKlient.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonRestKlient.java
@@ -1,0 +1,41 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import java.net.URI;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
+import no.nav.vedtak.konfig.KonfigVerdi;
+
+
+@ApplicationScoped
+public class OrganisasjonRestKlient {
+
+    private static final String ENDPOINT_KEY = "organisasjon.rs.url";
+    private static final String DEFAULT_URI = "https://modapp.adeo.no/ereg/api/v1/organisasjon";
+
+    private OidcRestClient oidcRestClient;
+    private URI endpoint;
+
+    public OrganisasjonRestKlient() {
+    }
+
+    @Inject
+    public OrganisasjonRestKlient(OidcRestClient oidcRestClient,
+                                  @KonfigVerdi(value = ENDPOINT_KEY, defaultVerdi = DEFAULT_URI) URI endpoint) {
+        this.oidcRestClient = oidcRestClient;
+        this.endpoint = endpoint;
+    }
+
+    public OrganisasjonEReg hentOrganisasjon(String orgnummer) {
+        var request = URI.create(endpoint.toString() + "/" + orgnummer);
+        return oidcRestClient.get(request, OrganisasjonEReg.class);
+    }
+
+    public OrganisasjonAdresse hentOrganisasjonAdresse(String orgnummer) {
+        var request = URI.create(endpoint.toString() + "/" + orgnummer);
+        return oidcRestClient.get(request, OrganisasjonAdresse.class);
+    }
+
+}

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonstypeEReg.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonstypeEReg.java
@@ -1,0 +1,21 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OrganisasjonstypeEReg {
+    JURIDISK_ENHET("JuridiskEnhet"),
+    VIRKSOMHET("Virksomhet"),
+    ORGLEDD("Organisasjonsledd")
+    ;
+
+    private final String kode;
+
+    @JsonValue
+    public String getKode() {
+        return this.kode;
+    }
+
+    private OrganisasjonstypeEReg(String kode) {
+        this.kode = kode;
+    }
+}

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/package-info.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Integrasjon mot NAVs enhetsregister
+ *
+ * @see Dokumentasjon https://confluence.adeo.no/display/FEL/EREG+-+Tjeneste+REST+ereg.api
+ * @see Swagger https://modapp-q1.adeo.no/ereg/api/swagger-ui.html#/
+ *
+ */
+package no.nav.vedtak.felles.integrasjon.organisasjon;

--- a/integrasjon/ereg-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/ereg-klient/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/integrasjon/ereg-klient/src/test/java/no/nav/vedtak/felles/integrasjon/organisasjon/EregRestTest.java
+++ b/integrasjon/ereg-klient/src/test/java/no/nav/vedtak/felles/integrasjon/organisasjon/EregRestTest.java
@@ -1,0 +1,131 @@
+package no.nav.vedtak.felles.integrasjon.organisasjon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class EregRestTest {
+
+    private static ObjectMapper mapper;
+
+    private static final String json = "{\n" +
+        "  \"organisasjonsnummer\": \"990983666\",\n" +
+        "  \"type\": \"Virksomhet\",\n" +
+        "  \"navn\": {\n" +
+        "    \"redigertnavn\": \"NAV IKT\",\n" +
+        "    \"navnelinje1\": \"NAV IKT\",\n" +
+        "    \"bruksperiode\": {\n" +
+        "      \"fom\": \"2015-02-23T08:04:53.2\"\n" +
+        "    },\n" +
+        "    \"gyldighetsperiode\": {\n" +
+        "      \"fom\": \"2010-04-09\"\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"organisasjonDetaljer\": {\n" +
+        "    \"registreringsdato\": \"2007-03-05T00:00:00\",\n" +
+        "    \"opphoersdato\": \"2018-11-06\",\n" +
+        "    \"enhetstyper\": [\n" +
+        "      {\n" +
+        "        \"enhetstype\": \"BEDR\",\n" +
+        "        \"bruksperiode\": {\n" +
+        "          \"fom\": \"2018-11-07T04:02:27.436\"\n" +
+        "        },\n" +
+        "        \"gyldighetsperiode\": {\n" +
+        "          \"fom\": \"2007-03-05\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    ],\n" +
+        "    \"naeringer\": [\n" +
+        "      {\n" +
+        "        \"naeringskode\": \"84.300\",\n" +
+        "        \"hjelpeenhet\": false,\n" +
+        "        \"bruksperiode\": {\n" +
+        "          \"fom\": \"2014-05-22T01:18:10.661\"\n" +
+        "        },\n" +
+        "        \"gyldighetsperiode\": {\n" +
+        "          \"fom\": \"2006-07-01\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    ],\n" +
+        "    \"navn\": [\n" +
+        "      {\n" +
+        "        \"redigertnavn\": \"NAV IKT\",\n" +
+        "        \"navnelinje1\": \"NAV IKT\",\n" +
+        "        \"bruksperiode\": {\n" +
+        "          \"fom\": \"2015-02-23T08:04:53.2\"\n" +
+        "        },\n" +
+        "        \"gyldighetsperiode\": {\n" +
+        "          \"fom\": \"2010-04-09\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    ],\n" +
+        "    \"forretningsadresser\": [\n" +
+        "      {\n" +
+        "        \"type\": \"Forretningsadresse\",\n" +
+        "        \"adresselinje1\": \"Sannergata 2\",\n" +
+        "        \"postnummer\": \"0557\",\n" +
+        "        \"landkode\": \"NO\",\n" +
+        "        \"kommunenummer\": \"0301\",\n" +
+        "        \"bruksperiode\": {\n" +
+        "          \"fom\": \"2015-02-23T10:38:34.403\"\n" +
+        "        },\n" +
+        "        \"gyldighetsperiode\": {\n" +
+        "          \"fom\": \"2007-08-23\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    ],\n" +
+        "    \"postadresser\": [\n" +
+        "      {\n" +
+        "        \"type\": \"Postadresse\",\n" +
+        "        \"adresselinje1\": \"Postboks 5 St Olavs plass\",\n" +
+        "        \"postnummer\": \"0130\",\n" +
+        "        \"landkode\": \"NO\",\n" +
+        "        \"kommunenummer\": \"0301\",\n" +
+        "        \"bruksperiode\": {\n" +
+        "          \"fom\": \"2015-02-23T10:38:34.403\"\n" +
+        "        },\n" +
+        "        \"gyldighetsperiode\": {\n" +
+        "          \"fom\": \"2010-10-08\"\n" +
+        "        }\n" +
+        "      }\n" +
+        "    ],\n" +
+        "    \"sistEndret\": \"2014-02-17\"\n" +
+        "  },\n" +
+        "  \"virksomhetDetaljer\": {\n" +
+        "    \"enhetstype\": \"BEDR\",\n" +
+        "    \"oppstartsdato\": \"2006-07-01\"\n" +
+        "  }\n" +
+        "}";
+
+    @BeforeClass
+    public static void setup() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+    }
+
+    @Test
+    public void mapping_organisasjon() throws IOException {
+        var org = fromJson(json, OrganisasjonEReg.class);
+
+        assertThat(org.getNavn()).isEqualTo("NAV IKT");
+        assertThat(org.getType()).isEqualTo(OrganisasjonstypeEReg.VIRKSOMHET);
+    }
+
+    @Test
+    public void mapping_adresse() throws IOException {
+        var org = fromJson(json, OrganisasjonAdresse.class);
+
+        assertThat(org.getNavn()).isEqualTo("NAV IKT");
+        assertThat(org.getKorrespondanseadresse().getAdresselinje1()).isEqualTo("Postboks 5 St Olavs plass");
+    }
+
+    private static <T> T fromJson(String json, Class<T> clazz) throws IOException {
+        return mapper.readerFor(clazz).readValue(json);
+    }
+}

--- a/integrasjon/ereg-klient/src/test/java/no/nav/vedtak/felles/integrasjon/organisasjon/EregRestTest.java
+++ b/integrasjon/ereg-klient/src/test/java/no/nav/vedtak/felles/integrasjon/organisasjon/EregRestTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
@@ -107,6 +108,7 @@ public class EregRestTest {
     public static void setup() {
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Test

--- a/integrasjon/pom.xml
+++ b/integrasjon/pom.xml
@@ -32,6 +32,7 @@
 		<module>arbeidsforhold-klient</module>
 		<module>organisasjon-klient</module>
 		<module>organisasjon-v5-klient</module>
+        <module>ereg-klient</module>
 		<module>kodeverk-klient</module>
 		<module>sigrun-klient</module>
 		<module>unleash-klient</module>


### PR DESCRIPTION
Enkel RS-klient som dekker OrganisasjonV4 + 5
To målgrupper
* Basis bruk med navn og registreringsdato for fpsak, k9sak, fpoppdrag, k9oppdrag, etc
* Bruk til brev m/verge+fullmektig: fpformidling, fptilbake, (k9klage?)

Abakus + Risk og andre som har spesielle informasjonsbehov og driver mer avanserte oppslag har sin egen klient (mapping av juridiske enheter til unike virksomheter).

Blir vi kvitt OrgV4+5 før ferien ?