### PR TITLE
Oauth2RestClient

### DIFF
--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OAuth2AccessTokenClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OAuth2AccessTokenClient.java
@@ -1,0 +1,90 @@
+package no.nav.vedtak.felles.integrasjon.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+class OAuth2AccessTokenClient  {
+    private static final ObjectMapper mapper = DefaultJsonMapper.getObjectMapper();
+
+    private final CloseableHttpClient closeableHttpClient;
+    private final URI tokenEndpoint;
+    private final URI tokenEndpointProxy;
+    private final String clientId;
+    private final String clientSecret;
+    private final RequestConfig requestConfig;
+
+    OAuth2AccessTokenClient(
+        CloseableHttpClient closeableHttpClient,
+        URI tokenEndpoint,
+        URI tokenEndpointProxy,
+        String clientId,
+        String clientSecret) {
+        this.closeableHttpClient = closeableHttpClient;
+        this.tokenEndpoint = tokenEndpoint;
+        this.tokenEndpointProxy = tokenEndpointProxy;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.requestConfig = requestConfig(tokenEndpointProxy);
+    }
+
+    String hentAccessToken(Set<String> scopes) {
+        return hentTokens(scopes).get("access_token").asText();
+    }
+
+    private ObjectNode hentTokens(Set<String> scopes) {
+        var entity = entity(scopes);
+        var httpPost = httpPost(entity);
+        String responseEntity;
+        try {
+            responseEntity = closeableHttpClient.execute(httpPost, new BasicResponseHandler());
+        } catch (IOException e) {
+            throw OidcRestClientFeil.FACTORY.ioException(OidcRestClientFeil.formatterURI(tokenEndpoint), e).toException();
+        }
+        try {
+            return (ObjectNode) mapper.readTree(responseEntity);
+        } catch (JsonProcessingException e) {
+            throw DefaultJsonMapper.DefaultJsonMapperFeil.FACTORY.kunneIkkeSerialisereJson(e).toException();
+        }
+    }
+
+    private String entity(Set<String> scopes) {
+        return "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret + "&scope=" + String.join(" ", scopes);
+    }
+
+    private static RequestConfig requestConfig(URI tokenEndpointProxy) {
+        if (tokenEndpointProxy == null) return null;
+        HttpHost httpHostProxy = HttpHost.create(tokenEndpointProxy.toString());
+        return RequestConfig.custom()
+            .setProxy(httpHostProxy)
+            .build();
+    }
+
+    private HttpPost httpPost(String entity) {
+        HttpPost post = new HttpPost(tokenEndpoint);
+        post.setEntity(new StringEntity(entity, StandardCharsets.UTF_8));
+        post.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString());
+        if (requestConfig != null) {
+            post.setConfig(requestConfig);
+        }
+        return post;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "<tokenEndpoint=" + tokenEndpoint + ", clientId=" + clientId + ", clientSecret=***, tokenEndpointProxy=" + tokenEndpointProxy + ">";
+    }
+}

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OAuth2RestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OAuth2RestClient.java
@@ -1,0 +1,105 @@
+package no.nav.vedtak.felles.integrasjon.rest;
+
+import no.nav.vedtak.util.LRUCache;
+import org.apache.http.impl.client.HttpClients;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static no.nav.vedtak.felles.integrasjon.rest.RestClientSupportProdusent.createHttpClient;
+
+public class OAuth2RestClient extends AbstractOidcRestClient {
+    private static final String CACHE_KEY = "OAuth2RestClient";
+    private final Set<String> scopes;
+
+    private final OAuth2AccessTokenClient oAuth2AccessTokenClient;
+    private final LRUCache<String, String> cache;
+
+    private OAuth2RestClient(
+        URI tokenEndpoint,
+        URI tokenEndpointProxy,
+        String clientId,
+        String clientSecret,
+        Set<String> scopes) {
+        super(createHttpClient());
+        // Bruker default client for tokens da client konfigurert i RestClientSupportProdusent feiler mot Azure p.g.a. headere som blir satt by default.
+        this.oAuth2AccessTokenClient = new OAuth2AccessTokenClient(HttpClients.createDefault(), tokenEndpoint, tokenEndpointProxy, clientId, clientSecret);
+        this.scopes = scopes;
+        this.cache = new LRUCache<>(1, Duration.ofMinutes(15).toMillis());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    String getOIDCToken() {
+        var cachedAccessToken = cache.get(CACHE_KEY);
+        if (cachedAccessToken != null) {
+            return cachedAccessToken;
+        }
+        var nyttAccessToken = oAuth2AccessTokenClient.hentAccessToken(scopes);
+        cache.put(CACHE_KEY, nyttAccessToken);
+        return nyttAccessToken;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "<scopes=" + scopes + ", oAuth2AccessTokenClient=" + oAuth2AccessTokenClient.toString() + ">";
+    }
+
+    public static class Builder {
+        private String clientId;
+        private String clientSecret;
+        private URI tokenEndpoint;
+        private URI tokenEndpointProxy;
+        private Set<String> scopes;
+
+        private Builder() {
+            scopes = new HashSet<>();
+        }
+
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder clientSecret(String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        public Builder tokenEndpoint(URI tokenEndpoint) {
+            this.tokenEndpoint = tokenEndpoint;
+            return this;
+        }
+
+        public Builder tokenEndpointProxy(URI tokenEndpointProxy) {
+            this.tokenEndpointProxy = tokenEndpointProxy;
+            return this;
+        }
+
+        public Builder scopes(String... scopes) {
+            return this.scopes(Set.of(scopes));
+        }
+
+        public Builder scopes(Set<String> scopes) {
+            this.scopes.addAll(scopes);
+            return this;
+        }
+
+        public OAuth2RestClient build() {
+            if (scopes.isEmpty()) throw new IllegalArgumentException("Må settes minst et scope.");
+            return new OAuth2RestClient(
+                requireNonNull(tokenEndpoint),
+                tokenEndpointProxy,
+                requireNonNull(clientId),
+                requireNonNull(clientSecret),
+                scopes
+            );
+        }
+    }
+}

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
@@ -85,7 +85,7 @@ public class RestClientSupportProdusent {
     }
 
     @SuppressWarnings("resource")
-    private CloseableHttpClient createHttpClient() {
+    static CloseableHttpClient createHttpClient() {
         // Create connection configuration
         ConnectionConfig defaultConnectionConfig = ConnectionConfig.custom()
                 .setCharset(Consts.UTF_8)


### PR DESCRIPTION
Må legges inn som en ny klient her for å følge det mønsteret som er blitt brukt på andre integrasjoner.

Bør etter det være minimalt med endringer i SpokelseKlient som må gjøres i Abakus. Mest bare hente config for å lage en `Oauth2RestClient` 