### PR TITLE
NOJIRA saf query for å hente journalposter som inneholder dokument

### DIFF
--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/SafTjeneste.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/SafTjeneste.java
@@ -153,7 +153,7 @@ public class SafTjeneste {
     }
 
     private List<Journalpost> ekstraherTilknyttedeJournalposter(TilknyttedeJournalposterQuery query, GraphQlResponse graphQlResponse) {
-        if (graphQlResponse.getData() == null || graphQlResponse.getData().getJournalpost() == null) {
+        if (graphQlResponse.getData() == null || graphQlResponse.getData().getTilknyttedeJournalposter() == null) {
             throw FEILFACTORY.safResponsTom(query).toException();
         }
         return graphQlResponse.getData().getTilknyttedeJournalposter();

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/GrapQlData.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/GrapQlData.java
@@ -1,5 +1,7 @@
 package no.nav.vedtak.felles.integrasjon.saf.graphql;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -20,13 +22,17 @@ public class GrapQlData {
     @JsonProperty("dokumentoversiktFagsak")
     private DokumentoversiktFagsak dokumentoversiktFagsak;
 
+    @JsonProperty("tilknyttedeJournalposter")
+    private List<Journalpost> tilknyttedeJournalposter;
+
     @JsonCreator
     public GrapQlData(@JsonProperty("journalpost") Journalpost journalpost,
-                      @JsonProperty("dokumentoversiktFagsakQuery") DokumentoversiktFagsak dokumentoversiktFagsak) {
+                      @JsonProperty("dokumentoversiktFagsakQuery") DokumentoversiktFagsak dokumentoversiktFagsak,
+                      @JsonProperty("tilknyttedeJournalposter") List<Journalpost> tilknyttedeJournalposter) {
         this.journalpost = journalpost;
         this.dokumentoversiktFagsak = dokumentoversiktFagsak;
+        this.tilknyttedeJournalposter = tilknyttedeJournalposter;
     }
-
 
     public Journalpost getJournalpost() {
         return journalpost;
@@ -36,11 +42,16 @@ public class GrapQlData {
         return dokumentoversiktFagsak;
     }
 
+    public List<Journalpost> getTilknyttedeJournalposter() {
+        return tilknyttedeJournalposter;
+    }
+
     @Override
     public String toString() {
         return "GrapQlData{" +
             "journalpost=" + journalpost +
             ", dokumentoversiktFagsak=" + dokumentoversiktFagsak +
+            ", tilknyttedeJournalposter=" + tilknyttedeJournalposter +
             '}';
     }
 }

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/Tilknytning.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/Tilknytning.java
@@ -1,0 +1,5 @@
+package no.nav.vedtak.felles.integrasjon.saf.graphql;
+
+public enum Tilknytning {
+    GJENBRUK
+}

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/TilknyttedeJournalposterQuery.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/TilknyttedeJournalposterQuery.java
@@ -1,0 +1,27 @@
+package no.nav.vedtak.felles.integrasjon.saf.graphql;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TilknyttedeJournalposterQuery implements SafQuery {
+
+    @NotNull
+    private String dokumentInfoId;
+
+    public TilknyttedeJournalposterQuery(@NotNull String dokumentInfoId) {
+        this.dokumentInfoId = dokumentInfoId;
+    }
+
+    public String getDokumentInfoId() {
+        return dokumentInfoId;
+    }
+
+    @Override
+    public String toString() {
+        return "TilknyttedeJournalposterQuery{" +
+            "dokumentInfoId='" + dokumentInfoId + '\'' +
+            '}';
+    }
+
+}

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/Variables.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/graphql/Variables.java
@@ -19,6 +19,12 @@ public class Variables {
     @JsonProperty("fagsaksystem")
     private String fagsaksystem;
 
+    @JsonProperty("dokumentInfoId")
+    private String dokumentInfoId;
+
+    @JsonProperty("tilknytning")
+    private Tilknytning tilknytning;
+
     public Variables(String journalpostId) {
         this.journalpostId = journalpostId;
     }
@@ -28,12 +34,19 @@ public class Variables {
         this.fagsaksystem = fagsaksystem;
     }
 
+    public Variables(String dokumentInfoId, Tilknytning tilknytning) {
+        this.dokumentInfoId = dokumentInfoId;
+        this.tilknytning = tilknytning;
+    }
+
     @Override
     public String toString() {
         return "Variables{" +
             "journalpostId='" + journalpostId + '\'' +
             ", fagsakId='" + fagsakId + '\'' +
             ", fagsaksystem='" + fagsaksystem + '\'' +
+            ", dokumentInfoId='" + dokumentInfoId + '\'' +
+            ", tilknytning=" + tilknytning +
             '}';
     }
 }

--- a/integrasjon/saf-klient/src/main/resources/saf/tilknyttedeJournalposterQuery.graphql
+++ b/integrasjon/saf-klient/src/main/resources/saf/tilknyttedeJournalposterQuery.graphql
@@ -1,0 +1,9 @@
+query ($dokumentInfoId: String!, $tilknytning: Tilknytning!) {
+  tilknyttedeJournalposter(
+    dokumentInfoId: $dokumentInfoId
+    tilknytning: $tilknytning
+  ) {
+    journalpostId
+    eksternReferanseId
+  }
+}

--- a/integrasjon/saf-klient/src/test/java/no/nav/vedtak/felles/integrasjon/saf/SafTjenesteTest.java
+++ b/integrasjon/saf-klient/src/test/java/no/nav/vedtak/felles/integrasjon/saf/SafTjenesteTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
+import java.util.Objects;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -23,6 +25,7 @@ import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
 import no.nav.vedtak.felles.integrasjon.saf.graphql.DokumentoversiktFagsakQuery;
 import no.nav.vedtak.felles.integrasjon.saf.graphql.HentDokumentQuery;
 import no.nav.vedtak.felles.integrasjon.saf.graphql.JournalpostQuery;
+import no.nav.vedtak.felles.integrasjon.saf.graphql.TilknyttedeJournalposterQuery;
 import no.nav.vedtak.felles.integrasjon.saf.rest.model.Journalpost;
 import no.nav.vedtak.felles.integrasjon.saf.rest.model.VariantFormat;
 
@@ -82,6 +85,19 @@ public class SafTjenesteTest {
         Journalpost journalpost = safTjeneste.hentJournalpostInfo(query);
 
         assertThat(journalpost.getJournalpostId()).isNotEmpty();
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    public void skal_returnere_tilknyttet_journalpost() throws IOException {
+        // tilknyttedeJournalposter(dokumentInfoId:"469211538", tilknytning:GJENBRUK)
+        var query = new TilknyttedeJournalposterQuery("dokumentInfoId");
+        when(entity.getContent()).thenReturn(getClass().getClassLoader().getResourceAsStream("saf/tilknyttetResponse.json"));
+
+        List<Journalpost> journalposter = safTjeneste.hentTilknyttedeJournalposter(query);
+
+        assertThat(journalposter).hasSize(2);
+        assertThat(journalposter.stream().map(Journalpost::getEksternReferanseId).filter(Objects::nonNull).findFirst()).isPresent();
     }
 
     @SuppressWarnings("resource")

--- a/integrasjon/saf-klient/src/test/resources/saf/tilknyttetResponse.json
+++ b/integrasjon/saf-klient/src/test/resources/saf/tilknyttetResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "tilknyttedeJournalposter": [
+      {
+        "journalpostId": "452676760",
+        "eksternReferanseId": "AR325412583"
+      },
+      {
+        "journalpostId": "439560100",
+        "eksternReferanseId": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Legger til et query for å hente alle journalposter m/kun eksternref som inneholder en dokumentId (kloningsprosess i Gosys).
Skal man bruke dette i fx abakus til å finne en manglende AltInn-referanse gitt en journalpostId så blir rekkefølgen
* SAF: Hent hentJournalpostInfo jpi
* SAF: hentTilknyttedeJournalposter(jpi.getDokumenter().get(0).getDokumentInfoId()) relaterteJp
* relaterteJp.stream().map(getEksternReferanseId),filter(NonNull).findFirst().orElse(null)