### PR TITLE
NOJIRA støtte for PDLs token-konvensjon

### DIFF
--- a/integrasjon/pdl-klient/src/main/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlient.java
+++ b/integrasjon/pdl-klient/src/main/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlient.java
@@ -39,6 +39,7 @@ import no.nav.vedtak.feil.deklarasjon.DeklarerteFeil;
 import no.nav.vedtak.feil.deklarasjon.TekniskFeil;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClientResponseHandler;
+import no.nav.vedtak.felles.integrasjon.rest.UserAndSystemOidcRestClient;
 import no.nav.vedtak.konfig.KonfigVerdi;
 
 @Dependent
@@ -61,7 +62,7 @@ public class PdlKlient {
 
     @Inject
     public PdlKlient(@KonfigVerdi(value = "pdl.base.url", defaultVerdi = "https://localhost:8063/rest/api/pdl") URI endpoint,
-                     OidcRestClient restKlient) {
+                     UserAndSystemOidcRestClient restKlient) {
         this.graphqlEndpoint = URI.create(endpoint.toString() + "/graphql");
         this.restKlient = restKlient;
     }

--- a/integrasjon/pdl-klient/src/test/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlientTest.java
+++ b/integrasjon/pdl-klient/src/test/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlientTest.java
@@ -22,12 +22,13 @@ import no.nav.pdl.HentPersonQueryRequest;
 import no.nav.pdl.NavnResponseProjection;
 import no.nav.pdl.PersonResponseProjection;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
+import no.nav.vedtak.felles.integrasjon.rest.UserAndSystemOidcRestClient;
 
 public class PdlKlientTest {
 
     private PdlKlient pdlKlient;
 
-    private OidcRestClient restClient;
+    private UserAndSystemOidcRestClient restClient;
     private CloseableHttpResponse response;
     private HttpEntity entity;
 
@@ -36,7 +37,7 @@ public class PdlKlientTest {
     @BeforeEach
     public void setUp() throws IOException {
         // Service setup
-        restClient = mock(OidcRestClient.class);
+        restClient = mock(UserAndSystemOidcRestClient.class);
         URI endpoint = URI.create("dummyendpoint/graphql");
         pdlKlient = new PdlKlient(endpoint, restClient);
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcRestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcRestClient.java
@@ -1,10 +1,8 @@
 package no.nav.vedtak.felles.integrasjon.rest;
 
-import java.io.IOException;
-
 import org.apache.http.impl.client.CloseableHttpClient;
 
-import no.nav.vedtak.isso.OpenAMHelper;
+import no.nav.vedtak.isso.SystemUserIdTokenProvider;
 import no.nav.vedtak.sikkerhet.context.SubjectHandler;
 import no.nav.vedtak.sikkerhet.domene.SAMLAssertionCredential;
 
@@ -32,15 +30,10 @@ public class OidcRestClient extends AbstractOidcRestClient {
         throw OidcRestClientFeil.FACTORY.klarteIkkeSkaffeOIDCToken().toException();
     }
 
-    // FIXME (u139158): PK-50281 STS for SAML til OIDC
-    // I mellomtiden bruker vi systemets OIDC-token, dvs vi propagerer ikke
-    // sikkerhetskonteksten
+    // TODO fra P2: Kalle STS for å veksle SAML til OIDC.
+    // Gammel - bør heller sanere WS som tilbys
     private String veksleSamlTokenTilOIDCToken(@SuppressWarnings("unused") SAMLAssertionCredential samlToken) {
-        try {
-            return new OpenAMHelper().getToken().getIdToken().getToken();
-        } catch (IOException e) {
-            throw OidcRestClientFeil.FACTORY.feilVedHentingAvSystemToken(e).toException();
-        }
+        return SystemUserIdTokenProvider.getSystemUserIdToken().getToken();
     }
 
 }

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
@@ -32,10 +32,12 @@ public class RestClientSupportProdusent {
 
     private final OidcRestClient oidcRestClient;
     private final SystemUserOidcRestClient systemUserOidcRestClient;
+    private final UserAndSystemOidcRestClient userAndSystemOidcRestClient;
 
     public RestClientSupportProdusent() {
         this.oidcRestClient = createOidcRestClient();
         this.systemUserOidcRestClient = creatSystemUserOidcRestClient();
+        this.userAndSystemOidcRestClient = createUserAndSystemOidcRestClient();
     }
 
     /**
@@ -72,6 +74,11 @@ public class RestClientSupportProdusent {
         return systemUserOidcRestClient;
     }
 
+    @Produces
+    public UserAndSystemOidcRestClient getUserAndSystemOidcRestClient() {
+        return userAndSystemOidcRestClient;
+    }
+
     private OidcRestClient createOidcRestClient() {
         CloseableHttpClient closeableHttpClient = createHttpClient();
         return new OidcRestClient(closeableHttpClient);
@@ -80,6 +87,11 @@ public class RestClientSupportProdusent {
     private SystemUserOidcRestClient creatSystemUserOidcRestClient() {
         CloseableHttpClient closeableHttpClient = createHttpClient();
         return new SystemUserOidcRestClient(closeableHttpClient);
+    }
+
+    private UserAndSystemOidcRestClient createUserAndSystemOidcRestClient() {
+        CloseableHttpClient closeableHttpClient = createHttpClient();
+        return new UserAndSystemOidcRestClient(closeableHttpClient);
     }
 
     static CloseableHttpClient createHttpClient() {

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/UserAndSystemOidcRestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/UserAndSystemOidcRestClient.java
@@ -1,0 +1,52 @@
+package no.nav.vedtak.felles.integrasjon.rest;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+
+import no.nav.vedtak.isso.SystemUserIdTokenProvider;
+import no.nav.vedtak.sikkerhet.context.SubjectHandler;
+
+/**
+ * Blir til PGA PDL som skal ha både userToken og consumerToken - de kan være like eller ulike
+ */
+public class UserAndSystemOidcRestClient extends AbstractOidcRestClient {
+
+    private static final String OIDC_AUTH_HEADER_PREFIX = "Bearer ";
+    private static final String NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token";
+
+    public UserAndSystemOidcRestClient(CloseableHttpClient client) {
+        super(client);
+    }
+
+    @Override
+    protected CloseableHttpResponse doExecute(HttpHost target, HttpRequest request, HttpContext context) throws IOException {
+        request.setHeader(NAV_CONSUMER_TOKEN_HEADER, OIDC_AUTH_HEADER_PREFIX + systemUserOIDCToken());
+
+        return super.doExecute(target, request, context);
+    }
+
+
+    @Override
+    protected String getOIDCToken() {
+        String oidcToken = SubjectHandler.getSubjectHandler().getInternSsoToken();
+        if (oidcToken != null) {
+            return oidcToken;
+        }
+
+        var samlToken = SubjectHandler.getSubjectHandler().getSamlToken();
+        if (samlToken != null) {
+            // Arv fra P2: Kalle STS for å veksle SAML til OIDC. Eller heller sanere WS som tilbys
+            return systemUserOIDCToken();
+        }
+        throw OidcRestClientFeil.FACTORY.klarteIkkeSkaffeOIDCToken().toException();
+    }
+
+    private String systemUserOIDCToken() {
+        return SystemUserIdTokenProvider.getSystemUserIdToken().getToken();
+    }
+}


### PR DESCRIPTION
PDL skal ha token for user/system i Authorization og systemtoken i Nav-Consumer-Token

Abakus/Risk bruker en get-metode med extra auth som bruker getOIDCToken() - den vil ikke gi systemtoken i alle tilfelle og vil ikke fungere for PDL