### PR TITLE
NOJIRA fjern systemspesifikke feilkoder

### DIFF
--- a/integrasjon/aktoer-klient/src/test/java/no/nav/vedtak/felles/integrasjon/aktør/klient/AktørConsumerTest.java
+++ b/integrasjon/aktoer-klient/src/test/java/no/nav/vedtak/felles/integrasjon/aktør/klient/AktørConsumerTest.java
@@ -50,7 +50,7 @@ public class AktørConsumerTest {
     @Test
     public void skalKasteIntegrasjonExceptionMedFeilmeldingForAndreFeil() throws Exception {
         when(mockAktoerV2.hentAktoerIdForIdent(any())).thenThrow(opprettSOAPFaultException("annen feil"));
-        assertTrue(assertThrows(IntegrasjonException.class, () -> consumer.hentAktørIdForPersonIdent("123")).getMessage().contains("FP-942048"));
+        assertTrue(assertThrows(IntegrasjonException.class, () -> consumer.hentAktørIdForPersonIdent("123")).getMessage().contains("F-942048"));
     }
 
     private static SOAPFaultException opprettSOAPFaultException(String faultString) throws SOAPException {

--- a/integrasjon/journal-klient/src/test/java/no/nav/vedtak/felles/integrasjon/journal/v3/JournalConsumerTest.java
+++ b/integrasjon/journal-klient/src/test/java/no/nav/vedtak/felles/integrasjon/journal/v3/JournalConsumerTest.java
@@ -41,14 +41,14 @@ public class JournalConsumerTest {
     public void skalKasteIntegrasjonsfeilNårWebserviceSenderSoapFaul_hentDokument() throws Exception {
         when(mockWebservice.hentDokument(any(HentDokumentRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
         var e = assertThrows(IntegrasjonException.class, () -> consumer.hentDokument(mock(HentDokumentRequest.class)));
-        assertEquals(e.getKode(), "FP-942048");
+        assertEquals(e.getKode(), "F-942048");
     }
 
     @Test
     public void skalKasteIntegrasjonsfeilNårWebserviceSenderSoapFault_kjerneJournalpostListe() throws Exception {
         when(mockWebservice.hentKjerneJournalpostListe(any(HentKjerneJournalpostListeRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
         var e = assertThrows(IntegrasjonException.class, () -> consumer.hentKjerneJournalpostListe(mock(HentKjerneJournalpostListeRequest.class)));
-        assertEquals(e.getKode(), "FP-942048");
+        assertEquals(e.getKode(), "F-942048");
 
     }
 
@@ -56,7 +56,7 @@ public class JournalConsumerTest {
     public void skalKasteIntegrasjonsfeilNårWebserviceSenderSoapFault_hentDokumentUrl() throws Exception {
         when(mockWebservice.hentDokumentURL(any(HentDokumentURLRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
         var e = assertThrows(IntegrasjonException.class, () -> consumer.hentDokumentURL(mock(HentDokumentURLRequest.class)));
-        assertEquals(e.getKode(), "FP-942048");
+        assertEquals(e.getKode(), "F-942048");
     }
 
     private static SOAPFaultException opprettSOAPFaultException(String faultString) throws SOAPException {

--- a/integrasjon/kodeverk-klient/src/main/java/no/nav/vedtak/felles/integrasjon/kodeverk/KodeverkConsumer.java
+++ b/integrasjon/kodeverk-klient/src/main/java/no/nav/vedtak/felles/integrasjon/kodeverk/KodeverkConsumer.java
@@ -73,7 +73,7 @@ public class KodeverkConsumer {
     interface KodeverkWebServiceFeil extends DeklarerteFeil {
         KodeverkWebServiceFeil FACTORY = FeilFactory.create(KodeverkWebServiceFeil.class);
 
-        @IntegrasjonFeil(feilkode = "FP-942049", feilmelding = "Kodeverktjenesten returnerte en SOAP Fault: %s", logLevel = LogLevel.WARN)
+        @IntegrasjonFeil(feilkode = "F-942049", feilmelding = "Kodeverktjenesten returnerte en SOAP Fault: %s", logLevel = LogLevel.WARN)
         Feil soapFaultFraKall(String webservice, WebServiceException soapException);
     }
 

--- a/integrasjon/pdl-klient/src/main/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlient.java
+++ b/integrasjon/pdl-klient/src/main/java/no/nav/vedtak/felles/integrasjon/pdl/PdlKlient.java
@@ -155,10 +155,10 @@ public class PdlKlient {
     interface PdlTjenesteFeil extends DeklarerteFeil { // NOSONAR - internt interface er ok her
         PdlTjenesteFeil FEILFACTORY = FeilFactory.create(PdlTjenesteFeil.class); // NOSONAR ok med konstant
 
-        @TekniskFeil(feilkode = "K9-539237", feilmelding = "Forespørsel til PDL feilet for spørring %s", logLevel = LogLevel.WARN)
+        @TekniskFeil(feilkode = "F-539237", feilmelding = "Forespørsel til PDL feilet for spørring %s", logLevel = LogLevel.WARN)
         Feil safForespørselFeilet(String query, Throwable t);
 
-        @TekniskFeil(feilkode = "K9-399735", feilmelding = "Feil fra PDL ved utført query. Error: %s", logLevel = LogLevel.WARN)
+        @TekniskFeil(feilkode = "F-399735", feilmelding = "Feil fra PDL ved utført query. Error: %s", logLevel = LogLevel.WARN)
         Feil forespørselReturnerteFeil(String response);
     }
 }

--- a/integrasjon/person-klient/src/test/java/no/nav/vedtak/felles/integrasjon/person/PersonConsumerTest.java
+++ b/integrasjon/person-klient/src/test/java/no/nav/vedtak/felles/integrasjon/person/PersonConsumerTest.java
@@ -41,14 +41,14 @@ public class PersonConsumerTest {
     public void skalKasteIntegrasjonsfeilNårWebserviceSenderSoapFault_hentPerson() throws Exception {
         when(mockWebservice.hentPerson(any(HentPersonRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
         assertTrue(assertThrows(IntegrasjonException.class, () -> consumer.hentPersonResponse(mock(HentPersonRequest.class))).getKode()
-                .equals("FP-942048"));
+                .equals("F-942048"));
     }
 
     @Test
     public void skalKasteIntegrasjonsfeilNårWebserviceSenderSoapFault_hentPersonHistorikk() throws Exception {
         when(mockWebservice.hentPersonhistorikk(any(HentPersonhistorikkRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
         assertTrue(assertThrows(IntegrasjonException.class, () -> consumer.hentPersonhistorikkResponse(mock(HentPersonhistorikkRequest.class)))
-                .getKode().equals("FP-942048"));
+                .getKode().equals("F-942048"));
 
     }
 
@@ -57,7 +57,7 @@ public class PersonConsumerTest {
         when(mockWebservice.hentGeografiskTilknytning(any(HentGeografiskTilknytningRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
 
         assertTrue(assertThrows(IntegrasjonException.class, () -> consumer.hentGeografiskTilknytning(mock(HentGeografiskTilknytningRequest.class)))
-                .getKode().equals("FP-942048"));
+                .getKode().equals("F-942048"));
     }
 
     private static SOAPFaultException opprettSOAPFaultException(String faultString) throws SOAPException {

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/SafTjeneste.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/SafTjeneste.java
@@ -193,10 +193,10 @@ public class SafTjeneste {
     interface SafTjenesteFeil extends DeklarerteFeil { // NOSONAR - internt interface er ok her
         SafTjenesteFeil FEILFACTORY = FeilFactory.create(SafTjenesteFeil.class); // NOSONAR ok med konstant
 
-        @TekniskFeil(feilkode = "K9-240613", feilmelding = "Forespørsel til SAF feilet for spørring %s", logLevel = LogLevel.WARN)
+        @TekniskFeil(feilkode = "F-240613", feilmelding = "Forespørsel til SAF feilet for spørring %s", logLevel = LogLevel.WARN)
         Feil safForespørselFeilet(String query, Throwable t);
 
-        @TekniskFeil(feilkode = "K9-588730", feilmelding = "Feil fra SAF ved utført query. Error: %s", logLevel = LogLevel.WARN)
+        @TekniskFeil(feilkode = "F-588730", feilmelding = "Feil fra SAF ved utført query. Error: %s", logLevel = LogLevel.WARN)
         Feil forespørselReturnerteFeil(String response);
     }
 }

--- a/integrasjon/webservice/src/main/java/no/nav/vedtak/felles/integrasjon/felles/ws/SoapWebServiceFeil.java
+++ b/integrasjon/webservice/src/main/java/no/nav/vedtak/felles/integrasjon/felles/ws/SoapWebServiceFeil.java
@@ -13,12 +13,12 @@ import no.nav.vedtak.feil.deklarasjon.TekniskFeil;
 public interface SoapWebServiceFeil extends DeklarerteFeil {
     SoapWebServiceFeil FACTORY = FeilFactory.create(SoapWebServiceFeil.class);
 
-    @IntegrasjonFeil(feilkode = "FP-942048", feilmelding = "SOAP tjenesten [ %s ] returnerte en SOAP Fault: %s", logLevel = LogLevel.WARN)
+    @IntegrasjonFeil(feilkode = "F-942048", feilmelding = "SOAP tjenesten [ %s ] returnerte en SOAP Fault: %s", logLevel = LogLevel.WARN)
     Feil soapFaultIwebserviceKall(String webservice, WebServiceException soapException);
 
     @TekniskFeil(feilkode = "F-668217", feilmelding = "Feilet utlogging.", logLevel = LogLevel.WARN)
     Feil feiletUtlogging(LoginException e);
-    
+
     @IntegrasjonFeil(feilkode = "F-134134", feilmelding = "SOAP tjenesten [ %s ] returnerte en feil som trolig er midlertidig: %s", logLevel = LogLevel.INFO)
     Feil midlertidigFeil(String webservice, WebServiceException exception);
 }


### PR DESCRIPTION
Holde F-konvensjonen så lenge vi bruker VLException.

@espennav  får dere gjort PdlKlientMedCache generisk (uten Tema.OMS) ?
Her kan det caches smartere - svar fra hentFnrForAktørId kan legge inn i begge caches - den gir current mapping
Men det kan ikke hentAktørIdForFnr gjøre ...