### PR TITLE
Velge spesifikk versjon av json-smart. 

### DIFF
--- a/felles/sikkerhet/sikkerhet/pom.xml
+++ b/felles/sikkerhet/sikkerhet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -72,18 +72,16 @@
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
                 <exclusion>
-                	<groupId>org.hibernate</groupId>
-                	<artifactId>hibernate-entitymanager</artifactId>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-entitymanager</artifactId>
                 </exclusion>
                 <exclusion>
-                	<groupId>org.hibernate</groupId>
-                	<artifactId>hibernate-core</artifactId>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
                 </exclusion>
                 <exclusion>
-                	<groupId>org.hibernate.common</groupId>
-                	<artifactId>
-                		hibernate-commons-annotations
-                	</artifactId>
+                    <groupId>org.hibernate.common</groupId>
+                    <artifactId>hibernate-commons-annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -96,7 +94,7 @@
             <artifactId>javax.json-api</artifactId>
         </dependency>
         <dependency>
-        	<!-- kun for Xacml - kan erstattes ved å bytte JsonUtil til Jackson ObjectMapper -->
+            <!-- kun for Xacml - kan erstattes ved å bytte JsonUtil til Jackson ObjectMapper -->
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-p-provider</artifactId>
         </dependency>
@@ -110,6 +108,17 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.3</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Da slipper avhengige bygg å sjekke alle mulige versjoner (inkl snapshot)