### PR TITLE
Legacy token provider for back kompabilitet

### DIFF
--- a/felles/abac-legacy/pom.xml
+++ b/felles/abac-legacy/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>felles</artifactId>
+        <groupId>no.nav.foreldrepenger.felles</groupId>
+        <version>0.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>felles-abac-legacy</artifactId>
+    <name>Felles :: ABAC</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles.sikkerhet</groupId>
+            <artifactId>felles-sikkerhet</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-feil</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-log</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-util</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-abac</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-feil</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-log</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>no.nav.foreldrepenger.felles</groupId>
+                    <artifactId>felles-util</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/felles/abac-legacy/src/main/java/no/nav/foreldrepenger/sikkerhet/abac/LegacyTokenProvider.java
+++ b/felles/abac-legacy/src/main/java/no/nav/foreldrepenger/sikkerhet/abac/LegacyTokenProvider.java
@@ -1,0 +1,22 @@
+package no.nav.foreldrepenger.sikkerhet.abac;
+
+import javax.enterprise.context.Dependent;
+
+import no.nav.vedtak.sikkerhet.abac.TokenProvider;
+import no.nav.vedtak.sikkerhet.context.SubjectHandler;
+
+@Dependent
+public class LegacyTokenProvider implements TokenProvider {
+
+    public String getUid() {
+        return SubjectHandler.getSubjectHandler().getUid();
+    }
+
+    public String userToken() {
+        return SubjectHandler.getSubjectHandler().getInternSsoToken();
+    }
+
+    public String samlToken() {
+        return SubjectHandler.getSubjectHandler().getSamlToken().getTokenAsString();
+    }
+}

--- a/felles/abac-legacy/src/main/resources/META-INF/beans.xml
+++ b/felles/abac-legacy/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" 
+    version="2.0" 
+    bean-discovery-mode="annotated">
+</beans>

--- a/felles/abac/README.md
+++ b/felles/abac/README.md
@@ -6,19 +6,27 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/navikt/fp-felles)
 ![GitHub](https://img.shields.io/github/license/navikt/fp-felles)
 
-# Felles ABAC / bibliotek for fpsak som håndterer authentisering og auditloggin.
+# ABAC - bibliotek for fpsak som håndterer authentisering og auditloggin.
 Inneholder følgende moduler:
 * Audit logging med CEF (Common Event Format) som brukes i Arcsight.
 * PEP/PDP biblioteker for ABAC tilgangskontroll.
 
-# Migrering
-* BeskyttetRessursActionAttributt endrer navn til ActionType
-* @BeskyttetRessurs krever en obligatorisk parameter path=/path/til/tjenesten/som/brukes
-* @BeskyttetRessurs krever service=ServiceType.WEBSERVICE på alle WS grensesnitt (default: ServiceType.REST)
-* Implementer PdpRequestBuilder klasse.
-* Endre i koden no.nav.vedtak.sikkerhet.abac.AbacAttributtType til no.nav.foreldrepenger.sikkerhet.abac.domene.AbacAttributtType
-* Endre no.nav.vedtak.sikkerhet.abac.AbacAttributtSamling til no.nav.foreldrepenger.sikkerhet.abac.domene.BeskyttRessursAttributer
-* Endre no.nav.vedtak.sikkerhet.abac.BeskyttetRessursActionAttributt til no.nav.foreldrepenger.sikkerhet.abac.domene.ActionType
-* Endre no.nav.vedtak.sikkerhet.abac.AbacDto til no.nav.foreldrepenger.sikkerhet.abac.AbacDto
-* Endre no.nav.vedtak.sikkerhet.abac.AbacDataAttributter til no.nav.foreldrepenger.sikkerhet.abac.domene.AbacDataAttributter 
-* Endre no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt til no.nav.vedtak.sikkerhet.abac.AbacDtoSupplier
+### Migrering felles 3.2.x
+
+Alle appene som benytter abac trenger å legge inn følgende dependency:
+```
+<dependency>
+    <groupId>no.nav.foreldrepenger.felles</groupId>
+    <artifactId>felles-abac</artifactId>
+</dependency>
+```
+
+#### Legacy bruk
+Det vil mangle en implementasjon av TokenProvider og det er mulig å implementere den selv i appen eller bruke følgende modul:
+```
+<dependency>
+    <groupId>no.nav.foreldrepenger.felles</groupId>
+    <artifactId>felles-abac-legacy</artifactId>
+</dependency>
+```
+Denne kommer med en avhengighet til felles-sikkerhet og SubjectHandler.

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAttributtType.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAttributtType.java
@@ -1,8 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac;
 
-import no.nav.vedtak.log.sporingslogg.SporingsloggId;
-
-public interface AbacAttributtType extends SporingsloggId {
+public interface AbacAttributtType {
 
     boolean getMaskerOutput();
 

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessursInterceptor.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/BeskyttetRessursInterceptor.java
@@ -3,7 +3,6 @@ package no.nav.vedtak.sikkerhet.abac;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.List;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.Dependent;
@@ -14,11 +13,8 @@ import javax.interceptor.InvocationContext;
 import javax.jws.WebService;
 
 import org.jboss.weld.interceptor.util.proxy.TargetInstanceProxy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import no.nav.vedtak.exception.TekniskException;
-import no.nav.vedtak.log.sporingslogg.Sporingsdata;
 import no.nav.vedtak.util.env.Environment;
 
 @BeskyttetRessurs(action = BeskyttetRessursActionAttributt.DUMMY, resource = "")

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/StandardAbacAttributtType.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/StandardAbacAttributtType.java
@@ -49,7 +49,6 @@ public enum StandardAbacAttributtType implements AbacAttributtType {
         this.maskerOutput = maskerOutput;
     }
 
-    @Override
     public String getSporingsloggKode() {
         return sporingsloggEksternKode;
     }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/TokenProvider.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/TokenProvider.java
@@ -1,11 +1,27 @@
 package no.nav.vedtak.sikkerhet.abac;
 
+/**
+ * Interface brukes til å provide informasjon om brukeren som forespør tilgang til en ressurs i en applikasjon.
+ */
 public interface TokenProvider {
 
+    /**
+     * Identifikator til brukeren. Brukes i auditlogging.
+     * @return bruker id.
+     */
     String getUid();
 
+    /**
+     * OIDC tokenet til brukeren. Helst fra følgende providere: Tokendings, AzureAD, STS, OpenAM.
+     * Sendes til PDP (Policy Decision Point) og gir informasjon til ABAC om subject og auth level.
+     * @return bruker OIDC token.
+     */
     String userToken();
 
+    /**
+     * SAML tokenet til brukeren. Trenges ved kall fra WebService grensesnitt.
+     * Sendes til PDP (Policy Decision Point) og gir informasjon til ABAC om subject og auth level.
+     * @return bruker SAML token.
+     */
     String samlToken();
-
 }

--- a/felles/pom.xml
+++ b/felles/pom.xml
@@ -23,6 +23,7 @@
         <module>bom</module>
         <module>abac</module>
         <module>xmlutils</module>
+        <module>abac-legacy</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
felles-abac-legacy modul med LegacyTokenProvider implementasjon til å være back kompatibel.
Oppdatert README.