### PR TITLE
Revert MDC-endring og legg til alt-header-sjekk

### DIFF
--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
@@ -4,31 +4,29 @@ import static org.slf4j.MDC.get;
 import static org.slf4j.MDC.put;
 
 import java.util.Objects;
-import java.util.Optional;
+import java.util.Random;
 
 import javax.xml.namespace.QName;
 
 import org.slf4j.MDC;
 
 /**
- * Utility-klasse for kommunikasjon med MDC. (Knabbet fra modig-log-common)
+ * Utility-klasse for kommunikasjon med MDC.
+ * (Knabbet fra modig-log-common)
  */
 public final class MDCOperations {
     public static final String HTTP_HEADER_CALL_ID = "Nav-Callid";
+    public static final String HTTP_HEADER_ALT_CALL_ID = "nav-call-id";
     public static final String HTTP_HEADER_CONSUMER_ID = "Nav-Consumer-Id";
-    public static final String NAV_CONSUMER_ID = "Nav-ConsumerId";
-    public static final String NAV_CALL_ID = "Nav-CallId";
-    public static final String NAV_USER_ID = "Nav-userId";
 
-    @Deprecated
     public static final String MDC_CALL_ID = "callId";
-    @Deprecated
     public static final String MDC_USER_ID = "userId";
-    @Deprecated
     public static final String MDC_CONSUMER_ID = "consumerId";
 
     // QName for the callId header
     public static final QName CALLID_QNAME = new QName("uri:no.nav.applikasjonsrammeverk", MDC_CALL_ID);
+
+    private static final Random RANDOM = new Random();
 
     private MDCOperations() {
     }
@@ -38,32 +36,34 @@ public final class MDCOperations {
     }
 
     public static void putCallId(String callId) {
-        toMDC(NAV_CALL_ID, callId);
+        Objects.requireNonNull(callId, "callId can't be null");
+        put(MDC_CALL_ID, callId);
     }
 
     public static String getCallId() {
-        return get(NAV_CALL_ID);
+        return get(MDC_CALL_ID);
     }
 
     public static void removeCallId() {
-        remove(NAV_CALL_ID);
+        remove(MDC_CALL_ID);
     }
 
     public static void putConsumerId(String consumerId) {
-        toMDC(NAV_CONSUMER_ID, consumerId);
+        Objects.requireNonNull(consumerId, "consumerId can't be null");
+        put(MDC_CONSUMER_ID, consumerId);
     }
 
     public static String getConsumerId() {
-        return get(NAV_CONSUMER_ID);
+        return get(MDC_CONSUMER_ID);
     }
 
     public static void removeConsumerId() {
-        remove(NAV_CONSUMER_ID);
+        remove(MDC_CONSUMER_ID);
     }
 
     public static void putUserId(String userId) {
         Objects.requireNonNull(userId, "userId can't be null");
-        put(NAV_USER_ID, maskFnr(userId));
+        put(MDC_USER_ID, maskFnr(userId));
     }
 
     private static String maskFnr(String userId) {
@@ -74,37 +74,29 @@ public final class MDCOperations {
     }
 
     public static String getUserId() {
-        return get(NAV_USER_ID);
+        return get(MDC_USER_ID);
     }
 
     public static void removeUserId() {
-        remove(NAV_USER_ID);
+        remove(MDC_USER_ID);
     }
 
     public static String generateCallId() {
-        return CallIdGenerator.create();
+        var randomNr = RANDOM.nextInt(Integer.MAX_VALUE);
+        var systemTime = System.currentTimeMillis();
+        return "CallId_" + systemTime + '_' + randomNr;
     }
 
-    @Deprecated
     public static String getFromMDC(String key) {
-        return get(key);
+        return MDC.get(key);
     }
 
     public static void putToMDC(String key, String value) {
-        toMDC(key, value);
-    }
-
-    public static void putToMDC(String key, String value, String defaultValue) {
-        put(key, Optional.ofNullable(value).orElse(defaultValue));
+        put(key, value);
     }
 
     public static void remove(String key) {
         MDC.remove(key);
     }
 
-    private static void toMDC(String key, Object value) {
-        if (value != null) {
-            put(key, value.toString());
-        }
-    }
 }

--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
@@ -40,6 +40,13 @@ public final class MDCOperations {
         put(MDC_CALL_ID, callId);
     }
 
+    public static void ensureCallId() {
+        var callId = getCallId();
+        if (callId == null || callId.isBlank()) {
+            putCallId(generateCallId());
+        }
+    }
+
     public static String getCallId() {
         return get(MDC_CALL_ID);
     }

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/jaspic/OidcAuthModule.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/jaspic/OidcAuthModule.java
@@ -151,9 +151,12 @@ public class OidcAuthModule implements ServerAuthModule {
 
     public void setCallAndConsumerId(HttpServletRequest request) {
         String callId = request.getHeader(MDCOperations.HTTP_HEADER_CALL_ID); // NOSONAR Akseptertet headere
+        String callId1 = request.getHeader(MDCOperations.HTTP_HEADER_ALT_CALL_ID); // NOSONAR Akseptertet headere
         if (callId != null) {
             MDCOperations.putCallId(callId);
-        } else {
+        } if (callId1 != null) {
+            MDCOperations.putCallId(callId1);
+        }else {
             MDCOperations.putCallId();
         }
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
@@ -76,7 +76,6 @@ public abstract class AbstractJerseyRestClient {
     public static final String NAV_CONSUMER_TOKEN_HEADER = "Nav-Consumer-Token";
     public static final String DEFAULT_NAV_CALLID = "Nav-Callid";
     public static final String ALT_NAV_CALL_ID = "nav-call-id";
-    public static final String ALT_NAV_CALL_ID1 = "callId";
 
     public static final String HEADER_CORRELATION_ID = "X-Correlation-ID";
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/StandardHeadersRequestInterceptor.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/StandardHeadersRequestInterceptor.java
@@ -1,7 +1,6 @@
 package no.nav.vedtak.felles.integrasjon.rest.jersey;
 
 import static no.nav.vedtak.felles.integrasjon.rest.jersey.AbstractJerseyRestClient.ALT_NAV_CALL_ID;
-import static no.nav.vedtak.felles.integrasjon.rest.jersey.AbstractJerseyRestClient.ALT_NAV_CALL_ID1;
 import static no.nav.vedtak.felles.integrasjon.rest.jersey.AbstractJerseyRestClient.DEFAULT_NAV_CALLID;
 import static no.nav.vedtak.felles.integrasjon.rest.jersey.AbstractJerseyRestClient.DEFAULT_NAV_CONSUMERID;
 import static no.nav.vedtak.felles.integrasjon.rest.jersey.AbstractJerseyRestClient.HEADER_CORRELATION_ID;

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/StandardHeadersRequestInterceptor.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/StandardHeadersRequestInterceptor.java
@@ -21,7 +21,6 @@ class StandardHeadersRequestInterceptor implements HttpRequestInterceptor {
     public void process(HttpRequest req, HttpContext context) throws HttpException, IOException {
         req.addHeader(DEFAULT_NAV_CALLID, getCallId());
         req.addHeader(ALT_NAV_CALL_ID, getCallId());
-        req.addHeader(ALT_NAV_CALL_ID1, getCallId());
         req.addHeader(HEADER_CORRELATION_ID, getCallId());
         req.addHeader(DEFAULT_NAV_CONSUMERID, getSubjectHandler().getConsumerId());
     }


### PR DESCRIPTION
MDC-endringen fra 6/5 må koordineres med prosesstask-rammeverket som antar "callId" + dobbelsjekke at apps ikke går rett mot MDC og ikke via MDCOperations.
