### PR TITLE
Fiks for ClientProtocolException –  "Cannot retry request with a non-repeatable request entity"

### DIFF
--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
@@ -13,6 +13,8 @@ import static no.nav.vedtak.log.metrics.MetricsUtil.utvidMedHistogram;
 import static org.glassfish.jersey.apache.connector.ApacheConnectorProvider.getHttpClient;
 import static org.glassfish.jersey.client.ClientProperties.CONNECT_TIMEOUT;
 import static org.glassfish.jersey.client.ClientProperties.READ_TIMEOUT;
+import static org.glassfish.jersey.client.ClientProperties.REQUEST_ENTITY_PROCESSING;
+import static org.glassfish.jersey.client.RequestEntityProcessing.BUFFERED;
 import static org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS;
 import static org.glassfish.jersey.logging.LoggingFeature.Verbosity.PAYLOAD_ANY;
 
@@ -134,7 +136,8 @@ public abstract class AbstractJerseyRestClient {
 
         this.client = ClientBuilder.newClient(cfg)
                 .property(CONNECT_TIMEOUT, ENV.getProperty(CONNECT_TIMEOUT, int.class, DEFAULT_CONNECT_TIMEOUT_MS))
-                .property(READ_TIMEOUT, ENV.getProperty(READ_TIMEOUT, int.class, DEFAULT_READ_TIMEOUT_MS));
+                .property(READ_TIMEOUT, ENV.getProperty(READ_TIMEOUT, int.class, DEFAULT_READ_TIMEOUT_MS))
+                .property(REQUEST_ENTITY_PROCESSING, BUFFERED);
 
         this.asyncClient = client.register(PropagatingThreadPoolExecutorProvider.class);
         this.invoker = invoker != null ? invoker : new ExceptionTranslatingInvoker();


### PR DESCRIPTION
By default settes denne til CHUNCKED. Dette fører til at entitet på requester sendes via streams. 

Hvis den initielle requesten feiler, så kan vil klienten prøve på nytt. Siden entiteten på requesten seraliseres som en stream så kan den ikke repetere requesten. Dette fører da til denne ClientProtocolException -> "Cannot retry request with a non-repeatable request entity. "-feilmeldingen. Klientene er dermed ikke repeatable.

Ved å sette denne til BUFFFERED så vil vi få en repetable HttpClient 

Ref. http://javadox.com/org.glassfish.jersey.bundles/apidocs/2.11/org/glassfish/jersey/client/ClientProperties.html#REQUEST_ENTITY_PROCESSING