### PR TITLE
Ta i bruk well-known metadata i StsAccessTokenConfig.

### DIFF
--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcProviderConfig.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcProviderConfig.java
@@ -6,7 +6,6 @@ import static no.nav.vedtak.sikkerhet.oidc.WellKnownConfigurationHelper.getJwksF
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -76,7 +75,9 @@ public final class OidcProviderConfig {
         idProviderConfigs.add(createOpenAmConfiguration(ENV.getProperty(OPEN_AM_WELL_KNOWN_URL)));
 
         // OIDC STS
-        idProviderConfigs.add(createStsConfiguration(ENV.getProperty(STS_WELL_KNOWN_URL)));
+        if (ENV.getProperty(STS_WELL_KNOWN_URL) != null || ENV.getProperty("oidc.sts.issuer.url") != null) { // Det er kanskje noen apper som ikke bruker STS token validering??
+            idProviderConfigs.add(createStsConfiguration(ENV.getProperty(STS_WELL_KNOWN_URL)));
+        }
 
         // Azure
         var azureKonfigUrl = ENV.getProperty(AZURE_WELL_KNOWN_URL);

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/WellKnownConfigurationHelper.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/WellKnownConfigurationHelper.java
@@ -23,23 +23,28 @@ public class WellKnownConfigurationHelper {
 
     private static Map<String, AuthorizationServerMetadata> wellKnownConfigMap = new HashMap<>();
 
-    public WellKnownConfigurationHelper() {}
-
     public static AuthorizationServerMetadata getWellKnownConfig(String discoveryUrl) {
         return wellKnownConfigMap.computeIfAbsent(discoveryUrl, WellKnownConfigurationHelper::retrieveAuthorizationServerMetadata);
     }
 
     public static Optional<String> getIssuerFra(String discoveryURL) {
-        LOG.debug("Henter Issuer fra {}", discoveryURL);
+        LOG.debug("Henter issuer fra {}", discoveryURL);
         return discoveryURL != null ?
             Optional.of(getWellKnownConfig(discoveryURL).getIssuer().getValue()) :
             Optional.empty();
     }
 
     public static Optional<String> getJwksFra(String discoveryURL) {
-        LOG.debug("Henter Jwks fra {}", discoveryURL);
+        LOG.debug("Henter jwki_uri fra {}", discoveryURL);
         return discoveryURL != null ?
             Optional.of(getWellKnownConfig(discoveryURL).getJWKSetURI().toString()) :
+            Optional.empty();
+    }
+
+    public static Optional<String> getTokenEndpointFra(String discoveryURL) {
+        LOG.debug("Henter token_endpoint fra {}", discoveryURL);
+        return discoveryURL != null ?
+            Optional.of(getWellKnownConfig(discoveryURL).getTokenEndpointURI().toString()) :
             Optional.empty();
     }
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/StsAccessTokenConfig.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/StsAccessTokenConfig.java
@@ -11,6 +11,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.vedtak.sikkerhet.oidc.WellKnownConfigurationHelper;
 
 @Dependent
 public class StsAccessTokenConfig {
@@ -23,18 +24,17 @@ public class StsAccessTokenConfig {
             new BasicNameValuePair(SCOPE, "openid"));
     private final String username;
     private final String password;
-    private final String stsUri;
-    private final String tokenEndpointPath;
+    private final String tokenEndpointUri;
 
     @Inject
-    StsAccessTokenConfig(@KonfigVerdi("oidc.sts.issuer.url") String issuerUrl,
-            @KonfigVerdi(value = "oidc.sts.token.path", defaultVerdi = DEFAULT_PATH, required = false) String tokenEndpointPath,
+    StsAccessTokenConfig(@KonfigVerdi(value = "oidc.sts.well.known.url", required = false) String wellKnownConfig,
+                         @KonfigVerdi(value = "oidc.sts.issuer.url", required = false) String issuerUrl,
+                         @KonfigVerdi(value = "oidc.sts.token.path", defaultVerdi = DEFAULT_PATH, required = false) String tokenEndpointPath,
             @KonfigVerdi("systembruker.username") String username,
             @KonfigVerdi("systembruker.password") String password) {
         this.username = username;
         this.password = password;
-        this.stsUri = issuerUrl;
-        this.tokenEndpointPath = tokenEndpointPath;
+        this.tokenEndpointUri = WellKnownConfigurationHelper.getTokenEndpointFra(wellKnownConfig).orElse(issuerUrl + tokenEndpointPath);
     }
 
     public String getUsername() {
@@ -46,9 +46,7 @@ public class StsAccessTokenConfig {
     }
 
     public URI getStsURI() {
-        return UriBuilder.fromUri(stsUri)
-                .path(tokenEndpointPath)
-                .build();
+        return UriBuilder.fromUri(tokenEndpointUri).build();
     }
 
     public List<NameValuePair> getFormParams() {
@@ -57,7 +55,7 @@ public class StsAccessTokenConfig {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [username=" + username + ", stsUri=" + stsUri + ", tokenEndpointPath=" + tokenEndpointPath + "]";
+        return getClass().getSimpleName() + " [username=" + username + ", tokenEndpointUri=" + tokenEndpointUri + "]";
     }
 
 }


### PR DESCRIPTION
- Tar vare på at kanskje ikke alle apper ønsker STS token validering
- token_endpoint støtte i WellKnownConfigHelper
- StsAccessTokenConfig henter token_endpoint fra server metadata (well-known) evtl faller back til issuer.url + token.path om well-known endepunkt er ikke konfigurert.