### PR TITLE
Fix: Disable cookie management on HttpClient

### DIFF
--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientSupportProdusent.java
@@ -102,6 +102,7 @@ public class RestClientSupportProdusent {
                 .setDefaultRequestConfig(requestConfig())
                 .setRetryHandler(new HttpRequestRetryHandler())
                 .setKeepAliveStrategy(createKeepAliveStrategy(30))
+                .disableCookieManagement()
                 .build();
     }
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/jersey/AbstractJerseyRestClient.java
@@ -125,7 +125,8 @@ public abstract class AbstractJerseyRestClient {
                             .uriMapper(new JerseyUriMapper())
                             .tags(List.of(Tag.of("client", getClass().getSimpleName())))
                             .build())
-                    .setConnectionManager(connectionManager());
+                    .setConnectionManager(connectionManager())
+                    .disableCookieManagement();
         });
         utvidMedHistogram(HTTPCOMPONENTS_HTTPCLIENT_REQUEST);
         filters.stream().forEach(cfg::register);


### PR DESCRIPTION
Målet er og få borte `Cookie rejected [amlbcookie="01", version:0, domain:devillo.no, path:/, expiry:null] Illegal 'domain' attribute "devillo.no". Domain of origin: "isso-q.adeo.no"`

Denne kommer da httpClienten setter alle cookies den samler I sin interne cookie lager. 