### PR TITLE
Refresh gir null-verdier når refreshtoken eldre enn 24h

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/OpenAmBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/OpenAmBrukerTokenKlient.java
@@ -50,6 +50,9 @@ public class OpenAmBrukerTokenKlient {
         var request = lagRequest(clientName, data);
         var response = GeneriskTokenKlient.hentToken(request, null);
         LOG.info("ISSO hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
+        if (response.token_type() == null || response.expires_in() == null) {
+            return Optional.empty();
+        }
         var token = new OpenIDToken(OpenIDProvider.ISSO, response.token_type(), new TokenString(response.id_token()),
             SCOPE, new TokenString(response.refresh_token()), response.expires_in());
         return Optional.of(token);

--- a/felles/pom.xml
+++ b/felles/pom.xml
@@ -27,7 +27,7 @@
     </modules>
 
     <properties>
-        <hibernate.version>5.6.6.Final</hibernate.version>
+        <hibernate.version>5.6.7.Final</hibernate.version>
         <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <jakarta.enterprise.version>2.0.2</jakarta.enterprise.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<mockito.version>4.4.0</mockito.version>
 		<assertj.version>3.22.0</assertj.version>
 		<no.nav.security.version>2.0.11</no.nav.security.version>
-        <micrometer.version>1.8.3</micrometer.version>
+        <micrometer.version>1.8.4</micrometer.version>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<argLine>-Dfile.encoding=UTF-8</argLine>
 	</properties>


### PR DESCRIPTION
Spesielt tilfelle når refresh-token i cookie er eldre enn 24 timer og man forsøker refresh som gir null-verdier