### PR TITLE
Legg til TokenX-funksjonalitet i felles-oidc + felles-sikkerhet

### DIFF
--- a/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJsonMapper.java
+++ b/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJsonMapper.java
@@ -1,6 +1,7 @@
 package no.nav.vedtak.mapper.json;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -42,11 +43,18 @@ public class DefaultJsonMapper {
             .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
     }
 
+    //    TODO: Vurder om disse bør med - tas ifm rydding i integrasjon-dtos (mest mulig records)
+    //        .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+    //        .setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+    //        .setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+    //        .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    //        .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY);
+
     public static <T> List<T> fromJson(String json, TypeReference<List<T>> typeReference) {
         try {
             return MAPPER.readValue(json, typeReference);
         } catch (IOException e) {
-            throw new TekniskException("F-919328", "Fikk IO exception ved parsing av JSON", e);
+            throw deserializationException(e);
         }
     }
 
@@ -54,7 +62,15 @@ public class DefaultJsonMapper {
         try {
             return MAPPER.readValue(json, clazz);
         } catch (IOException e) {
-            throw new TekniskException("FP-713328", "Fikk IO exception ved deserialisering av JSON", e);
+            throw deserializationException(e);
+        }
+    }
+
+    public static <T> T fromJson(URL json, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw deserializationException(e);
         }
     }
 
@@ -62,7 +78,7 @@ public class DefaultJsonMapper {
         try {
             return MAPPER.readTree(json);
         } catch (IOException e) {
-            throw new TekniskException("F-919328", "Fikk IO exception ved parsing av JSON", e);
+            throw deserializationException(e);
         }
     }
 
@@ -70,7 +86,23 @@ public class DefaultJsonMapper {
         try {
             return MAPPER.writeValueAsString(obj);
         } catch (IOException e) {
-            throw new TekniskException("F-208314", "Kunne ikke serialisere objekt til JSON", e);
+            throw serializationException(e);
         }
+    }
+
+    public static String toPrettyJson(Object obj) {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        } catch (IOException e) {
+            throw serializationException(e);
+        }
+    }
+
+    private static TekniskException deserializationException(IOException e) {
+        return new TekniskException("FP-713328", "Fikk IO exception ved deserialisering av JSON", e);
+    }
+
+    private static TekniskException serializationException(IOException e) {
+        return new TekniskException("F-208314", "Kunne ikke serialisere objekt til JSON", e);
     }
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/context/containers/AuthenticationLevelCredential.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/context/containers/AuthenticationLevelCredential.java
@@ -4,11 +4,21 @@ import javax.security.auth.Destroyable;
 
 public class AuthenticationLevelCredential implements Destroyable {
 
+    private static final Integer AUTHENTICATION_LEVEL_INTERN_BRUKER = 4;
+    private static final Integer AUTHENTICATION_LEVEL_EKSTERN_BRUKER = 4;
+
+    public static final String AUTHENTICATION_LEVEL_ID_PORTEN = "Level" + AUTHENTICATION_LEVEL_EKSTERN_BRUKER;
+
+
     private int authenticationLevel;
     private boolean destroyed;
 
     public AuthenticationLevelCredential(int authenticationLevel) {
         this.authenticationLevel = authenticationLevel;
+    }
+
+    public static AuthenticationLevelCredential forInternBruker() {
+        return new AuthenticationLevelCredential(AUTHENTICATION_LEVEL_INTERN_BRUKER);
     }
 
     public int getAuthenticationLevel() {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -1,5 +1,6 @@
 package no.nav.vedtak.sikkerhet.oidc.token;
 
+import java.net.URI;
 import java.util.Optional;
 
 import no.nav.vedtak.exception.TekniskException;
@@ -10,6 +11,7 @@ import no.nav.vedtak.sikkerhet.oidc.token.impl.AzureSystemTokenKlient;
 import no.nav.vedtak.sikkerhet.oidc.token.impl.BrukerTokenProvider;
 import no.nav.vedtak.sikkerhet.oidc.token.impl.OpenAmBrukerTokenKlient;
 import no.nav.vedtak.sikkerhet.oidc.token.impl.StsSystemTokenKlient;
+import no.nav.vedtak.sikkerhet.oidc.token.impl.TokenXExchangeKlient;
 
 public final class TokenProvider {
 
@@ -56,9 +58,9 @@ public final class TokenProvider {
         throw new TekniskException("F-872314", "Azure exchange ikke implementert ennå");
     }
 
-    public static OpenIDToken exchangeTokenX(String tokenToExchange, String audience) {
-        // Senere: bytte OBO token - ta inn kode fra rest. Trenger å lande JWT-bibliotek
-        throw new TekniskException("F-872314", "TokenX exchange ikke integrert ennå");
+    public static OpenIDToken exchangeTokenX(OpenIDToken token, String assertion, URI targetEndpoint) {
+        // Assertion må være generert av den som skal bytte. Et JWT, RSA-signert, basert på injisert private jwk
+        return TokenXExchangeKlient.exchangeToken(token, assertion, targetEndpoint);
     }
 
     private static OpenIDToken getTokenForBrukerMedFallbackDersomSaml(boolean fallback) {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/TokenXExchangeKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/TokenXExchangeKlient.java
@@ -1,0 +1,87 @@
+package no.nav.vedtak.sikkerhet.oidc.token.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.StringJoiner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.log.mdc.MDCOperations;
+import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDConfiguration;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
+import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
+
+public final class TokenXExchangeKlient {
+
+    private static final Environment ENV = Environment.current();
+    private static final String CLUSTER = ENV.getCluster().clusterName();
+    private static final String NAMESPACE = ENV.getNamespace().getName();
+
+    private static final Logger LOG = LoggerFactory.getLogger(TokenXExchangeKlient.class);
+
+    private static final String CLIENT_ID = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
+        .map(OpenIDConfiguration::clientId).orElse(null);
+    private static final URI TOKEN_ENDPOINT = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
+        .map(OpenIDConfiguration::tokenEndpoint).orElse(null);
+
+    private TokenXExchangeKlient() {
+        // NOSONAR
+    }
+
+    public static OpenIDToken exchangeToken(OpenIDToken token, String assertion, URI targetEndpoint) {
+        var audience = audience(targetEndpoint);
+        var response = hentToken(token, assertion, audience);
+        LOG.info("TokenX byttet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
+        return new OpenIDToken(OpenIDProvider.TOKENX, response.token_type(),
+            new TokenString(response.access_token()), audience, response.expires_in());
+    }
+
+    private static OidcTokenResponse hentToken(OpenIDToken token, String assertion, String audience) {
+        var request = HttpRequest.newBuilder()
+            .header("Nav-Consumer-Id", CLIENT_ID)
+            .header("Nav-Call-Id", MDCOperations.getCallId())
+            .header("Cache-Control", "no-cache")
+            .header("Content-type", "application/x-www-form-urlencoded")
+            .timeout(Duration.ofSeconds(10))
+            .uri(TOKEN_ENDPOINT)
+            .POST(ofFormData(token, assertion, audience))
+            .build();
+        return GeneriskTokenKlient.hentToken(request, null);
+    }
+
+    private static HttpRequest.BodyPublisher ofFormData(OpenIDToken token, String assertion, String audience) {
+        var formdata = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange&" +
+            "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&" +
+            "client_assertion=" + assertion + "&" +
+            "subject_token_type=urn:ietf:params:oauth:token-type:jwt&" +
+            "subject_token=" + token.token() + "&" +
+            "audience=" + audience;
+        return HttpRequest.BodyPublishers.ofString(formdata, UTF_8);
+    }
+
+    private static String audience(URI uri) {
+        String host = uri.getHost();
+        var elems = host.split("\\.");
+        var joiner = new StringJoiner(":");
+        joiner.add(CLUSTER);
+
+        if (elems.length == 1) {
+            joiner.add(NAMESPACE);
+            joiner.add(elems[0]);
+            return joiner.toString();
+        }
+        if (elems.length == 2) {
+            joiner.add(elems[1]);
+            joiner.add(elems[0]);
+            return joiner.toString();
+        }
+        throw new IllegalArgumentException("Kan ikke analysere " + host + "(" + elems.length + ")");
+    }
+}

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/loginmodule/oidc/OIDCLoginModule.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/loginmodule/oidc/OIDCLoginModule.java
@@ -36,7 +36,6 @@ import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 public class OIDCLoginModule extends LoginModuleBase {
 
     private static final Logger logger = LoggerFactory.getLogger(OIDCLoginModule.class);
-    private static final int AUTHENTICATION_LEVEL_INTERN_BRUKER = 4;
 
     // Set during initialize()
     private Subject subject;
@@ -84,7 +83,7 @@ public class OIDCLoginModule extends LoginModuleBase {
 
     @Override
     public void doCommit() throws LoginException {
-        authenticationLevelCredential = new AuthenticationLevelCredential(AUTHENTICATION_LEVEL_INTERN_BRUKER);
+        authenticationLevelCredential = AuthenticationLevelCredential.forInternBruker();
         String mdcConsumerId = MDCOperations.getConsumerId();
         if (mdcConsumerId != null) {
             this.consumerId = new ConsumerId(mdcConsumerId);

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXAssertionGenerator.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXAssertionGenerator.java
@@ -1,0 +1,74 @@
+package no.nav.vedtak.tokenx;
+
+import static com.nimbusds.jose.JOSEObjectType.JWT;
+import static com.nimbusds.jose.JWSAlgorithm.RS256;
+
+import java.net.URI;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDConfiguration;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+
+final class TokenXAssertionGenerator {
+
+    private static final Environment ENV = Environment.current();
+
+    private static final String CLIENT_ID = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
+        .map(OpenIDConfiguration::clientId).orElse(null);
+    private static final URI TOKEN_ENDPOINT = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
+        .map(OpenIDConfiguration::tokenEndpoint).orElse(null);
+    private static final RSAKey TOKENX_PRIVATE_KEY = Optional.ofNullable(ENV.getProperty("token.x.private.jwk"))
+        .map(TokenXAssertionGenerator::rsaKey).orElse(null);
+
+    private TokenXAssertionGenerator() {
+        // NOSONAR
+    }
+
+    public static String assertion() {
+        var now = Date.from(Instant.now());
+        try {
+            var claimsSet = new JWTClaimsSet.Builder()
+                .subject(CLIENT_ID)
+                .issuer(CLIENT_ID)
+                .audience(TOKEN_ENDPOINT.toString())
+                .issueTime(now)
+                .notBeforeTime(now)
+                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+            return sign(claimsSet).serialize();
+        } catch (JOSEException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static SignedJWT sign(JWTClaimsSet claimsSet) throws JOSEException {
+        var jwsHeader = new JWSHeader.Builder(RS256)
+            .keyID(TOKENX_PRIVATE_KEY.getKeyID())
+            .type(JWT).build();
+        var signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        signedJWT.sign(new RSASSASigner(TOKENX_PRIVATE_KEY.toPrivateKey()));
+        return signedJWT;
+    }
+
+    private static RSAKey rsaKey(String privateJwk) {
+        try {
+            return RSAKey.parse(privateJwk);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXchange.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXchange.java
@@ -1,0 +1,49 @@
+package no.nav.vedtak.tokenx;
+
+
+import static no.nav.vedtak.log.util.ConfidentialMarkerFilter.CONFIDENTIAL;
+
+import java.net.URI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
+import no.nav.vedtak.sikkerhet.oidc.token.SikkerhetContext;
+import no.nav.vedtak.sikkerhet.oidc.token.TokenProvider;
+
+/**
+ * Dette filteret skal brukes når man vet man mottar et token som støtter
+ * on-behalf-of, og når mottakende system krever kun dette
+ *
+ */
+public final class TokenXchange {
+    private static final Environment ENV = Environment.current();
+    private static final Logger LOG = LoggerFactory.getLogger(TokenXchange.class);
+
+    private TokenXchange() {
+        // NOSONAR
+    }
+
+    public static OpenIDToken exchange(URI targetEndpoint) {
+        var token = TokenProvider.getTokenUtenSamlFallback(SikkerhetContext.BRUKER);
+        return exchange(token, targetEndpoint);
+    }
+
+    public static OpenIDToken exchange(OpenIDToken token, URI targetEndpoint) {
+        if (token != null && OpenIDProvider.TOKENX.equals(token.provider())) {
+            LOG.trace(CONFIDENTIAL, "Veksler tokenX token {} for {}", token, targetEndpoint);
+            var assertion = TokenXAssertionGenerator.assertion();
+            return TokenProvider.exchangeTokenX(token, assertion, targetEndpoint);
+        } else {
+            if (token != null && ENV.isLocal()) {
+                LOG.warn("Dette er intet tokenX token, sender originalt token videre til {} siden VTP er mangelfull her", targetEndpoint);
+                return token;
+            } else {
+                throw new IllegalStateException("Dette er intet tokenX token");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dette er de-facto ikke i bruk, men tar vare på koden fra felles-integrasjon på passende steder.
Vi prøver unngå OBO med tokenX i dette rammeverket - men det skal være mulig.