### PR TITLE
Skisse til OpenAm replacement

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
@@ -44,6 +44,7 @@ public final class OidcProviderConfig {
     private static final String AZURE_CONFIG_JWKS_URI = "azure.openid.config.jwks.uri"; // naiserator
     private static final String AZURE_CONFIG_TOKEN_ENDPOINT = "azure.openid.config.token.endpoint"; // naiserator
     private static final String AZURE_CLIENT_ID = "azure.app.client.id"; // naiserator
+    private static final String AZURE_CLIENT_SECRET = "azure.app.client.secret"; // naiserator
     private static final String AZURE_HTTP_PROXY = "azure.http.proxy"; // settes ikke av naiserator
 
     private static final String TOKEN_X_WELL_KNOWN_URL = "token.x.well.known.url"; // naiserator
@@ -182,10 +183,12 @@ public final class OidcProviderConfig {
                 .orElseGet(() -> getJwksFra(wellKnownUrl, useProxy).orElse(null)),
             Optional.ofNullable(ENV.getProperty(AZURE_CONFIG_TOKEN_ENDPOINT))
                 .orElseGet(() -> getTokenEndpointFra(wellKnownUrl, useProxy).orElse(null)),
-            null,
+            Optional.ofNullable(ENV.getProperty(AZURE_CONFIG_TOKEN_ENDPOINT))
+                .map(s -> s.replace("/token", "/authorize"))
+                .orElseGet(() -> getAuthorizationEndpointFra(wellKnownUrl, useProxy).orElse(null)),
             !ENV.isLocal(), useProxy,
             ENV.getRequiredProperty(AZURE_CLIENT_ID),
-            null,
+            ENV.getProperty(AZURE_CLIENT_SECRET),
             true);
     }
 

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/WellKnownConfigurationHelper.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/WellKnownConfigurationHelper.java
@@ -71,6 +71,10 @@ public class WellKnownConfigurationHelper {
         return Optional.ofNullable(wellKnownURL).map(u -> getWellKnownConfig(u, null).authorization_endpoint());
     }
 
+    static Optional<String> getAuthorizationEndpointFra(String wellKnownURL, URI proxyUrl) {
+        return Optional.ofNullable(wellKnownURL).map(u -> getWellKnownConfig(u, proxyUrl).authorization_endpoint());
+    }
+
     private static WellKnownOpenIdConfiguration hentWellKnownConfig(String wellKnownURL, URI proxy) {
         try {
             if (wellKnownURL == null) return null;

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -70,7 +70,7 @@ public final class TokenProvider {
         var token = BrukerTokenProvider.getToken();
         if (token != null && token.token() != null && OpenIDProvider.AZUREAD.equals(token.provider()) &&
             IdentType.InternBruker.equals(BrukerTokenProvider.getIdentType())) {
-            return AzureBrukerTokenKlient.oboExchangeToken(token, scopes);
+            return AzureBrukerTokenKlient.instance().oboExchangeToken(token, scopes);
         }
         return token;
     }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -1,0 +1,75 @@
+package no.nav.vedtak.sikkerhet.oidc.token.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDConfiguration;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
+import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
+
+public class AzureBrukerTokenKlient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AzureBrukerTokenKlient.class);
+
+    private static final OpenIDConfiguration CONFIGURATION = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
+
+    public static OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
+        String data = "client_id=" + CONFIGURATION.clientId() +
+            "&scope=" + scopes +
+            "&code=" + authorizationCode +
+            "&redirect_uri=" + URLEncoder.encode(callback, UTF_8) +
+            "&grant_type=authorization_code" +
+            //"&code_verifier=" + "ThisIsntRandomButItNeedsToBe43CharactersLong" +
+            "&client_secret=" + CONFIGURATION.clientSecret();
+        var request = lagRequest(data);
+        var response = GeneriskTokenKlient.hentToken(request, null);
+        LOG.info("ISSO hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
+        return new OpenIDToken(OpenIDProvider.ISSO, response.token_type(), new TokenString(response.id_token()),
+            scopes, new TokenString(response.refresh_token()), response.expires_in());
+
+    }
+
+    public static Optional<OpenIDToken> refreshIdToken(OpenIDToken expiredToken, String scopes) {
+        if (expiredToken.refreshToken().isEmpty())
+            return Optional.empty();
+        //client_id=535fb089-9ff3-47b6-9bfb-4f1264799865
+        //&scope=https%3A%2F%2Fgraph.microsoft.com%2Fmail.read
+        //&refresh_token=OAAABAAAAiL9Kn2Z27UubvWFPbm0gLWQJVzCTE9UkP3pSx1aXxUjq...
+        //&grant_type=refresh_token
+        //&client_secret=sampleCredentia1s
+        var data = "client_id=" + CONFIGURATION.clientId() +
+            "&scope=" + scopes +
+            "&refresh_token=" + expiredToken.refreshToken().get() +
+            "&grant_type=refresh_token" +
+            "&client_secret=" + CONFIGURATION.clientSecret();
+        var request = lagRequest(data);
+        var response = GeneriskTokenKlient.hentToken(request, null);
+        LOG.info("ISSO hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
+        if (response.token_type() == null || response.expires_in() == null) {
+            return Optional.empty();
+        }
+        var token = new OpenIDToken(OpenIDProvider.ISSO, response.token_type(), new TokenString(response.id_token()),
+            scopes, new TokenString(response.refresh_token()), response.expires_in());
+        return Optional.of(token);
+    }
+
+    private static HttpRequest lagRequest(String data) {
+        return  HttpRequest.newBuilder()
+            .header("Cache-Control", "no-cache")
+            .header("Content-type", "application/x-www-form-urlencoded")
+            .timeout(Duration.ofSeconds(10))
+            .uri(CONFIGURATION.tokenEndpoint())
+            .POST(HttpRequest.BodyPublishers.ofString(data, UTF_8))
+            .build();
+    }
+
+}

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -2,6 +2,7 @@ package no.nav.vedtak.sikkerhet.oidc.token.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
@@ -12,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
-import no.nav.vedtak.sikkerhet.oidc.config.OpenIDConfiguration;
 import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
@@ -21,34 +21,57 @@ public class AzureBrukerTokenKlient {
 
     private static final Logger LOG = LoggerFactory.getLogger(AzureBrukerTokenKlient.class);
 
-    private static final OpenIDConfiguration CONFIGURATION = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElse(null);
+    private static volatile AzureBrukerTokenKlient INSTANCE; // NOSONAR
 
-    public static OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
-        String data = "client_id=" + CONFIGURATION.clientId() +
+    private final URI tokenEndpoint;
+    private final String clientId;
+    private final String clientSecret;
+    private final URI azureProxy;
+
+
+    public AzureBrukerTokenKlient() {
+        var provider = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
+        this.tokenEndpoint = provider.tokenEndpoint();
+        this.azureProxy = provider.proxy();
+        this.clientId = provider.clientId();
+        this.clientSecret = provider.clientSecret();
+    }
+
+    public static synchronized AzureBrukerTokenKlient instance() {
+        var inst = INSTANCE;
+        if (inst == null) {
+            inst = new AzureBrukerTokenKlient();
+            INSTANCE = inst;
+        }
+        return inst;
+    }
+
+    public OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
+        String data = "client_id=" + clientId +
             "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&code=" + authorizationCode +
             "&redirect_uri=" + URLEncoder.encode(callback, UTF_8) +
             "&grant_type=authorization_code" +
             //"&code_verifier=" + "ThisIsntRandomButItNeedsToBe43CharactersLong" +
-            "&client_secret=" + CONFIGURATION.clientSecret();
+            "&client_secret=" + clientSecret;
         var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, CONFIGURATION.proxy());
+        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
         LOG.info("AzureBruker hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
         return new OpenIDToken(OpenIDProvider.AZUREAD, response.token_type(), new TokenString(response.id_token()),
             scopes, new TokenString(response.refresh_token()), response.expires_in());
 
     }
 
-    public static Optional<OpenIDToken> refreshIdToken(OpenIDToken expiredToken, String scopes) {
+    public Optional<OpenIDToken> refreshIdToken(OpenIDToken expiredToken, String scopes) {
         if (expiredToken.refreshToken().isEmpty())
             return Optional.empty();
-        var data = "client_id=" + CONFIGURATION.clientId() +
+        var data = "client_id=" + clientId +
             "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&refresh_token=" + expiredToken.refreshToken().get() +
             "&grant_type=refresh_token" +
-            "&client_secret=" + CONFIGURATION.clientSecret();
+            "&client_secret=" + clientSecret;
         var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, CONFIGURATION.proxy());
+        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
         LOG.info("AzureBruker hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
         if (response.token_type() == null || response.expires_in() == null) {
             return Optional.empty();
@@ -58,27 +81,27 @@ public class AzureBrukerTokenKlient {
         return Optional.of(token);
     }
 
-    public static OpenIDToken oboExchangeToken(OpenIDToken incomingToken, String scopes) {
+    public OpenIDToken oboExchangeToken(OpenIDToken incomingToken, String scopes) {
         // TODO: vurder caching av incoming+scopes -> exchanged
-        var data = "client_id=" + CONFIGURATION.clientId() +
+        var data = "client_id=" + clientId +
             "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&assertion=" + incomingToken.token() +
             "&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" +
             "&requested_token_use=on_behalf_of" +
-            "&client_secret=" + CONFIGURATION.clientSecret();
+            "&client_secret=" + clientSecret;
         var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, CONFIGURATION.proxy());
+        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
         LOG.info("AzureBruker hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
         return new OpenIDToken(OpenIDProvider.AZUREAD, response.token_type(), new TokenString(response.access_token()),
             scopes, new TokenString(response.refresh_token()), response.expires_in());
     }
 
-    private static HttpRequest lagRequest(String data) {
+    private HttpRequest lagRequest(String data) {
         return  HttpRequest.newBuilder()
             .header("Cache-Control", "no-cache")
             .header("Content-type", "application/x-www-form-urlencoded")
             .timeout(Duration.ofSeconds(10))
-            .uri(CONFIGURATION.tokenEndpoint())
+            .uri(tokenEndpoint)
             .POST(HttpRequest.BodyPublishers.ofString(data, UTF_8))
             .build();
     }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -20,7 +20,7 @@ public class AzureBrukerTokenKlient {
 
     private static final Logger LOG = LoggerFactory.getLogger(AzureBrukerTokenKlient.class);
 
-    private static final OpenIDConfiguration CONFIGURATION = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
+    private static final OpenIDConfiguration CONFIGURATION = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElse(null);
 
     public static OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
         String data = "client_id=" + CONFIGURATION.clientId() +
@@ -31,7 +31,7 @@ public class AzureBrukerTokenKlient {
             //"&code_verifier=" + "ThisIsntRandomButItNeedsToBe43CharactersLong" +
             "&client_secret=" + CONFIGURATION.clientSecret();
         var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, null);
+        var response = GeneriskTokenKlient.hentToken(request, CONFIGURATION.proxy());
         LOG.info("ISSO hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
         return new OpenIDToken(OpenIDProvider.ISSO, response.token_type(), new TokenString(response.id_token()),
             scopes, new TokenString(response.refresh_token()), response.expires_in());
@@ -52,7 +52,7 @@ public class AzureBrukerTokenKlient {
             "&grant_type=refresh_token" +
             "&client_secret=" + CONFIGURATION.clientSecret();
         var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, null);
+        var response = GeneriskTokenKlient.hentToken(request, CONFIGURATION.proxy());
         LOG.info("ISSO hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
         if (response.token_type() == null || response.expires_in() == null) {
             return Optional.empty();

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -24,7 +25,7 @@ public class AzureBrukerTokenKlient {
 
     public static OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
         String data = "client_id=" + CONFIGURATION.clientId() +
-            "&scope=" + scopes +
+            "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&code=" + authorizationCode +
             "&redirect_uri=" + URLEncoder.encode(callback, UTF_8) +
             "&grant_type=authorization_code" +
@@ -47,7 +48,7 @@ public class AzureBrukerTokenKlient {
         //&grant_type=refresh_token
         //&client_secret=sampleCredentia1s
         var data = "client_id=" + CONFIGURATION.clientId() +
-            "&scope=" + scopes +
+            "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&refresh_token=" + expiredToken.refreshToken().get() +
             "&grant_type=refresh_token" +
             "&client_secret=" + CONFIGURATION.clientSecret();

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
@@ -44,10 +44,10 @@ public class AzureSystemTokenKlient {
 
     private AzureSystemTokenKlient() {
         var provider = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
-        tokenEndpoint = provider.tokenEndpoint();
-        azureProxy = provider.proxy();
-        clientId = provider.clientId();
-        clientSecret = ENV.getProperty("azure.app.client.secret", "foreldrepenger");
+        this.tokenEndpoint = provider.tokenEndpoint();
+        this.azureProxy = provider.proxy();
+        this.clientId = provider.clientId();
+        this.clientSecret = provider.clientSecret();
     }
 
     public synchronized OpenIDToken hentAccessToken(String scope) {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
@@ -3,6 +3,7 @@ package no.nav.vedtak.sikkerhet.oidc.token.impl;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -80,7 +81,8 @@ public class AzureSystemTokenKlient {
     }
 
     private static HttpRequest.BodyPublisher ofFormData(String clientId, String clientSecret, String scope) {
-        var formdata = "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret + "&scope=" + scope;
+        var encodedScope = URLEncoder.encode(scope, UTF_8);
+        var formdata = "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientSecret + "&scope=" + encodedScope;
         return HttpRequest.BodyPublishers.ofString(formdata, UTF_8);
     }
 

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/BrukerTokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/BrukerTokenProvider.java
@@ -3,6 +3,7 @@ package no.nav.vedtak.sikkerhet.oidc.token.impl;
 import java.util.Optional;
 
 import no.nav.vedtak.sikkerhet.context.SubjectHandler;
+import no.nav.vedtak.sikkerhet.context.containers.IdentType;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 import no.nav.vedtak.sikkerhet.oidc.token.SikkerhetContext;
 
@@ -27,5 +28,9 @@ public class BrukerTokenProvider {
 
     public static String getUserId() {
         return SubjectHandler.getSubjectHandler().getUid();
+    }
+
+    public static IdentType getIdentType() {
+        return SubjectHandler.getSubjectHandler().getIdentType();
     }
 }

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
@@ -1,0 +1,39 @@
+package no.nav.vedtak.isso.oidc;
+
+import java.util.Optional;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.isso.ressurs.AzureConfigProperties;
+import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
+import no.nav.vedtak.sikkerhet.oidc.token.impl.AzureBrukerTokenKlient;
+
+public final class AzureADTokenProvider {
+
+    private static final Environment ENV = Environment.current();
+
+    private static final String SCOPES = AzureConfigProperties.getAzureScopes().orElse("openid");
+
+    private static final String REFRESH_TIME = "no.nav.vedtak.sikkerhet.minimum_time_to_expiry_before_refresh.seconds";
+    public static final int DEFAULT_REFRESH_TIME = 120;
+
+
+    public static OpenIDToken exhangeAzureAuthCode(String authorizationCode, String callback) {
+        return AzureBrukerTokenKlient.exhangeAuthCode(authorizationCode, callback, SCOPES);
+    }
+
+    public static Optional<OpenIDToken> refreshAzureIdToken(OpenIDToken expiredToken) {
+        return AzureBrukerTokenKlient.refreshIdToken(expiredToken, SCOPES);
+    }
+
+    public static boolean isAzureTokenSoonExpired(OpenIDToken token) {
+        return tokenIsSoonExpired(token) && token.refreshToken().isPresent();
+    }
+
+    private static boolean tokenIsSoonExpired(OpenIDToken token) {
+        return token.expiresAtMillis() - System.currentTimeMillis() < getMinimumTimeToExpiryBeforeRefresh();
+    }
+
+    public static int getMinimumTimeToExpiryBeforeRefresh() {
+        return ENV.getProperty(REFRESH_TIME, Integer.class, DEFAULT_REFRESH_TIME) * 1000;
+    }
+}

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
@@ -11,7 +11,7 @@ public final class AzureADTokenProvider {
 
     private static final Environment ENV = Environment.current();
 
-    private static final String SCOPES = AzureConfigProperties.getAzureScopes().orElse("openid");
+    private static final String SCOPES = AzureConfigProperties.getAzureScopes();
 
     private static final String REFRESH_TIME = "no.nav.vedtak.sikkerhet.minimum_time_to_expiry_before_refresh.seconds";
     public static final int DEFAULT_REFRESH_TIME = 120;

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/AzureADTokenProvider.java
@@ -18,11 +18,11 @@ public final class AzureADTokenProvider {
 
 
     public static OpenIDToken exhangeAzureAuthCode(String authorizationCode, String callback) {
-        return AzureBrukerTokenKlient.exhangeAuthCode(authorizationCode, callback, SCOPES);
+        return AzureBrukerTokenKlient.instance().exhangeAuthCode(authorizationCode, callback, SCOPES);
     }
 
     public static Optional<OpenIDToken> refreshAzureIdToken(OpenIDToken expiredToken) {
-        return AzureBrukerTokenKlient.refreshIdToken(expiredToken, SCOPES);
+        return AzureBrukerTokenKlient.instance().refreshIdToken(expiredToken, SCOPES);
     }
 
     public static boolean isAzureTokenSoonExpired(OpenIDToken token) {

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
@@ -1,0 +1,54 @@
+package no.nav.vedtak.isso.ressurs;
+
+import java.math.BigInteger;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Optional;
+
+import no.nav.vedtak.isso.config.ServerInfo;
+import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+
+public class AzureAuthorizationRequestBuilder {
+
+    private static final SecureRandom RND = new SecureRandom();
+
+    private static final String SCOPE = "openid";
+
+    private String stateIndex;
+
+    public AzureAuthorizationRequestBuilder() {
+
+        byte[] bytes = new byte[20];
+        RND.nextBytes(bytes);
+        stateIndex = "state_" + new BigInteger(1, bytes).toString(16);
+    }
+
+    public String getStateIndex() {
+        return stateIndex;
+    }
+
+    public String buildRedirectString() {
+        var scopes = AzureConfigProperties.getAzureScopes()
+            .map(s -> s.replace("\\*", " "))
+            .orElse(SCOPE);
+        var providerConfig = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
+        var clientId = providerConfig.clientId();
+        var redirectUrl = ServerInfo.instance().getCallbackUrl();
+
+        //TODO - sjekke ut PKCE
+        //&code_challenge=YTFjNj......
+        //&code_challenge_method=S256
+
+        // KCD?  "?session=winssochain&authIndexType=service&authIndexValue=winssochain";
+        return providerConfig.authorizationEndpoint().toString() +
+            "&response_type=code" +
+            "&response_mode=query" +
+            "&scope=" + scopes +
+            "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8) +
+            "&state="+ getStateIndex() +
+            "&redirect_uri=" + URLEncoder.encode(redirectUrl, StandardCharsets.UTF_8);
+    }
+
+}

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
@@ -4,7 +4,6 @@ import java.math.BigInteger;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.util.Optional;
 
 import no.nav.vedtak.isso.config.ServerInfo;
 import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
@@ -13,8 +12,6 @@ import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
 public class AzureAuthorizationRequestBuilder {
 
     private static final SecureRandom RND = new SecureRandom();
-
-    private static final String SCOPE = "openid";
 
     private String stateIndex;
 
@@ -30,9 +27,7 @@ public class AzureAuthorizationRequestBuilder {
     }
 
     public String buildRedirectString() {
-        var scopes = AzureConfigProperties.getAzureScopes()
-            .map(s -> s.replace("\\*", " "))
-            .orElse(SCOPE);
+        var scopes = AzureConfigProperties.getAzureScopes();
         var providerConfig = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.AZUREAD).orElseThrow();
         var clientId = providerConfig.clientId();
         var redirectUrl = ServerInfo.instance().getCallbackUrl();

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureAuthorizationRequestBuilder.java
@@ -40,7 +40,7 @@ public class AzureAuthorizationRequestBuilder {
         return providerConfig.authorizationEndpoint().toString() +
             "&response_type=code" +
             "&response_mode=query" +
-            "&scope=" + scopes +
+            "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
             "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8) +
             "&state="+ getStateIndex() +
             "&redirect_uri=" + URLEncoder.encode(redirectUrl, StandardCharsets.UTF_8);

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
@@ -15,8 +15,11 @@ public final class AzureConfigProperties {
     // Sett = true for å aktivere
     private static final String AZURE_TRIAL_ENABLED = "fp.trial.azure.enabled";
 
+    private static final String OPENID_SCOPE = "openid";
 
-    private static final String AZURE_SCOPES = ENV.getProperty(AZURE_SCOPES_PROPERTY_NAME);
+
+    private static final String AZURE_SCOPES = Optional.ofNullable(ENV.getProperty(AZURE_SCOPES_PROPERTY_NAME))
+        .map(s -> s.replace("\\*", " ")).orElse(OPENID_SCOPE);
     private static final boolean AZURE_ENABLED  = Optional.ofNullable(ENV.getProperty(AZURE_TRIAL_ENABLED)).filter("true"::equals).isPresent();
 
     private AzureConfigProperties() {
@@ -28,7 +31,7 @@ public final class AzureConfigProperties {
         return AZURE_ENABLED;
     }
 
-    public static Optional<String> getAzureScopes() {
-        return Optional.ofNullable(AZURE_SCOPES);
+    public static String getAzureScopes() {
+        return AZURE_SCOPES;
     }
 }

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
@@ -10,12 +10,13 @@ public final class AzureConfigProperties {
 
     // En *-separert liste over scopes man ønsker inkludert i token - i starten brukes openid
     // Fx api://<cluster>:<namespace>:fplos/default*api://<cluster>:<namespace>:fpsak/default
+    // NB: dersom denne settes - så vurder å begynne med openid*offline_access*api://....
     private static final String AZURE_SCOPES_PROPERTY_NAME = "fp.trial.azure.scopes";
 
     // Sett = true for å aktivere
     private static final String AZURE_TRIAL_ENABLED = "fp.trial.azure.enabled";
 
-    private static final String OPENID_SCOPE = "openid";
+    private static final String OPENID_SCOPE = "openid offline_access";
 
 
     private static final String AZURE_SCOPES = Optional.ofNullable(ENV.getProperty(AZURE_SCOPES_PROPERTY_NAME))

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/AzureConfigProperties.java
@@ -1,0 +1,34 @@
+package no.nav.vedtak.isso.ressurs;
+
+import java.util.Optional;
+
+import no.nav.foreldrepenger.konfig.Environment;
+
+public final class AzureConfigProperties {
+
+    private static final Environment ENV = Environment.current();
+
+    // En *-separert liste over scopes man ønsker inkludert i token - i starten brukes openid
+    // Fx api://<cluster>:<namespace>:fplos/default*api://<cluster>:<namespace>:fpsak/default
+    private static final String AZURE_SCOPES_PROPERTY_NAME = "fp.trial.azure.scopes";
+
+    // Sett = true for å aktivere
+    private static final String AZURE_TRIAL_ENABLED = "fp.trial.azure.enabled";
+
+
+    private static final String AZURE_SCOPES = ENV.getProperty(AZURE_SCOPES_PROPERTY_NAME);
+    private static final boolean AZURE_ENABLED  = Optional.ofNullable(ENV.getProperty(AZURE_TRIAL_ENABLED)).filter("true"::equals).isPresent();
+
+    private AzureConfigProperties() {
+
+    }
+
+
+    public static boolean isAzureEnabled() {
+        return AZURE_ENABLED;
+    }
+
+    public static Optional<String> getAzureScopes() {
+        return Optional.ofNullable(AZURE_SCOPES);
+    }
+}

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/RelyingPartyCallback.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/ressurs/RelyingPartyCallback.java
@@ -58,7 +58,7 @@ public class RelyingPartyCallback {
 
         OpenIDToken token;
         if (AzureConfigProperties.isAzureEnabled()) {
-            token = new AzureADTokenProvider().exhangeAzureAuthCode(authorizationCode, ServerInfo.instance().getCallbackUrl());
+            token = AzureADTokenProvider.exhangeAzureAuthCode(authorizationCode, ServerInfo.instance().getCallbackUrl());
             if (!OidcTokenValidatorConfig.instance().getValidator(OpenIDProvider.AZUREAD).validate(token.primary()).isValid()) {
                 return status(FORBIDDEN).build();
             }

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
@@ -100,8 +100,6 @@ public class OidcTokenValidator {
                 return validateAzure(claims, subject);
             } else if (OpenIDProvider.TOKENX.equals(provider)) {
                 return validateTokenX(claims, subject);
-            } else if (OpenIDProvider.AZUREAD.equals(provider)) {
-                subject = Optional.ofNullable(claims.getStringClaimValue("NAVident")).orElse(subject);
             }
             return OidcTokenValidatorResult.valid(subject, claims.getExpirationTime().getValue());
         } catch (InvalidJwtException e) {

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
@@ -100,9 +100,10 @@ public class OidcTokenValidator {
                 return validateAzure(claims, subject);
             } else if (OpenIDProvider.TOKENX.equals(provider)) {
                 return validateTokenX(claims, subject);
-            } else {
-                return OidcTokenValidatorResult.valid(subject, claims.getExpirationTime().getValue());
+            } else if (OpenIDProvider.AZUREAD.equals(provider)) {
+                subject = Optional.ofNullable(claims.getStringClaimValue("NAVident")).orElse(subject);
             }
+            return OidcTokenValidatorResult.valid(subject, claims.getExpirationTime().getValue());
         } catch (InvalidJwtException e) {
             return OidcTokenValidatorResult.invalid(e.toString());
         } catch (MalformedClaimException e) {

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/oidc/OidcTokenValidator.java
@@ -100,8 +100,9 @@ public class OidcTokenValidator {
                 return validateAzure(claims, subject);
             } else if (OpenIDProvider.TOKENX.equals(provider)) {
                 return validateTokenX(claims, subject);
+            } else {
+                return OidcTokenValidatorResult.valid(subject, claims.getExpirationTime().getValue());
             }
-            return OidcTokenValidatorResult.valid(subject, claims.getExpirationTime().getValue());
         } catch (InvalidJwtException e) {
             return OidcTokenValidatorResult.invalid(e.toString());
         } catch (MalformedClaimException e) {


### PR DESCRIPTION
AzureAD-versjoner av det som finnes for OpenAm - antar at følger samme standard for RelyingPartyCallback
* Skal følge konvensjoner i Azure-dok for redirect to authorize + secret-based code->token + refresh.
* Validator sjekker for NAVident , ref nais-dok.

TODOs:
* PKCE og code_challenge / code_challenge_method / code_verifier. Needed for openId?
* Scopes - openid + offline_access (for refresh-token) - men ta med api:// for apps som det alltid kalles? 
* id_token vs access_token fra responsen - eksemplene viser samme verdi
* Evt lese om KCD og om Kerberos er en mulighet
* aud-validering - ref nais og azp_name
* Lage Azure-utgaver av PDL og SAF og sørge for OBO (TokenProvider getTokenForScopes()). 
* Trengs noe eget for kall videre til abakus/kalkulus - eller kan man passe incoming openid ?

Trenger finlesing