### PR TITLE
Standardiser på jose4j før jakarta

### DIFF
--- a/felles/abac/pom.xml
+++ b/felles/abac/pom.xml
@@ -45,12 +45,16 @@
             <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>

--- a/felles/pom.xml
+++ b/felles/pom.xml
@@ -94,6 +94,11 @@
                 <artifactId>felles-testutilities</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>0.7.11</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/felles/sikkerhet/pom.xml
+++ b/felles/sikkerhet/pom.xml
@@ -53,18 +53,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.7.11</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-core</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.interceptor</groupId>

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/OpenAmTokenProvider.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/isso/oidc/OpenAmTokenProvider.java
@@ -3,7 +3,6 @@ package no.nav.vedtak.isso.oidc;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.konfig.Environment;
-import no.nav.vedtak.sikkerhet.oidc.JwtUtil;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 import no.nav.vedtak.sikkerhet.oidc.token.impl.OpenAmBrukerTokenKlient;
 
@@ -19,8 +18,8 @@ public final class OpenAmTokenProvider {
         return OpenAmBrukerTokenKlient.exhangeAuthCode(authorizationCode, callback);
     }
 
-    public Optional<OpenIDToken> refreshOpenAmIdToken(OpenIDToken expiredToken) {
-        return OpenAmBrukerTokenKlient.refreshIdToken(expiredToken, JwtUtil.getClientName(expiredToken.token()));
+    public Optional<OpenIDToken> refreshOpenAmIdToken(OpenIDToken expiredToken, String clientName) {
+        return OpenAmBrukerTokenKlient.refreshIdToken(expiredToken, clientName);
     }
 
     public boolean isOpenAmTokenSoonExpired(OpenIDToken token) {

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXAssertionGenerator.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXAssertionGenerator.java
@@ -1,21 +1,14 @@
 package no.nav.vedtak.tokenx;
 
-import static com.nimbusds.jose.JOSEObjectType.JWT;
-import static com.nimbusds.jose.JWSAlgorithm.RS256;
-
 import java.net.URI;
-import java.text.ParseException;
-import java.time.Instant;
-import java.util.Date;
 import java.util.Optional;
-import java.util.UUID;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
+import org.jose4j.json.JsonUtil;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.lang.JoseException;
 
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.sikkerhet.oidc.config.ConfigProvider;
@@ -28,16 +21,20 @@ final class TokenXAssertionGenerator {
 
     private final String clientId;
     private final URI tokenEndpoint;
-    private final RSAKey privateKey;
+    private final RsaJsonWebKey privateKey;
 
 
     private TokenXAssertionGenerator() {
-        this.tokenEndpoint = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
-            .map(OpenIDConfiguration::tokenEndpoint).orElse(null);
-        this.clientId = ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX)
-            .map(OpenIDConfiguration::clientId).orElse(null);
-        this.privateKey = Optional.ofNullable(Environment.current().getProperty("token.x.private.jwk"))
-            .map(TokenXAssertionGenerator::rsaKey).orElse(null);
+            this(ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX).map(OpenIDConfiguration::tokenEndpoint).orElse(null),
+                ConfigProvider.getOpenIDConfiguration(OpenIDProvider.TOKENX).map(OpenIDConfiguration::clientId).orElse(null),
+                Optional.ofNullable(Environment.current().getProperty("token.x.private.jwk")).map(TokenXAssertionGenerator::rsaKey).orElse(null));
+    }
+
+    // Kun til Testformål
+    TokenXAssertionGenerator(URI tokenEndpoint, String clientId, RsaJsonWebKey privateKey) {
+        this.tokenEndpoint = tokenEndpoint;
+        this.clientId = clientId;
+        this.privateKey = privateKey;
     }
 
     public static synchronized TokenXAssertionGenerator instance() {
@@ -49,36 +46,32 @@ final class TokenXAssertionGenerator {
         return inst;
     }
     public String assertion() {
-        var now = Date.from(Instant.now());
         try {
-            var claimsSet = new JWTClaimsSet.Builder()
-                .subject(clientId)
-                .issuer(clientId)
-                .audience(tokenEndpoint.toString())
-                .issueTime(now)
-                .notBeforeTime(now)
-                .expirationTime(Date.from(Instant.now().plusSeconds(60)))
-                .jwtID(UUID.randomUUID().toString())
-                .build();
-            return sign(claimsSet).serialize();
-        } catch (JOSEException e) {
+            JwtClaims claims = new JwtClaims();
+            claims.setSubject(clientId);
+            claims.setIssuer(clientId);
+            claims.setAudience(tokenEndpoint.toString());
+            claims.setIssuedAtToNow();
+            claims.setNotBeforeMinutesInThePast(2);
+            claims.setExpirationTimeMinutesInTheFuture(1);
+            claims.setGeneratedJwtId();
+
+            JsonWebSignature jws = new JsonWebSignature();
+            jws.setPayload(claims.toJson());
+            jws.setKey(privateKey.getPrivateKey());
+            jws.setKeyIdHeaderValue(privateKey.getKeyId());
+            jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+            return jws.getCompactSerialization();
+        } catch (JoseException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
-    private SignedJWT sign(JWTClaimsSet claimsSet) throws JOSEException {
-        var jwsHeader = new JWSHeader.Builder(RS256)
-            .keyID(privateKey.getKeyID())
-            .type(JWT).build();
-        var signedJWT = new SignedJWT(jwsHeader, claimsSet);
-        signedJWT.sign(new RSASSASigner(privateKey.toPrivateKey()));
-        return signedJWT;
-    }
-
-    private static RSAKey rsaKey(String privateJwk) {
+    private static RsaJsonWebKey rsaKey(String privateJwk) {
         try {
-            return RSAKey.parse(privateJwk);
-        } catch (ParseException e) {
+            var map = JsonUtil.parseJson(privateJwk);
+            return new RsaJsonWebKey(map);
+        } catch (JoseException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/felles/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/jaspic/OidcAuthModuleTest.java
+++ b/felles/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/jaspic/OidcAuthModuleTest.java
@@ -243,7 +243,7 @@ public class OidcAuthModuleTest {
 
         AuthStatus result = authModule.validateRequest(request, subject, serviceSubject);
         assertThat(result).isEqualTo(AuthStatus.SEND_CONTINUE);
-        verify(idTokenProvider).refreshOpenAmIdToken(any());
+        verify(idTokenProvider).refreshOpenAmIdToken(any(), any());
     }
 
     @Test
@@ -266,11 +266,11 @@ public class OidcAuthModuleTest {
                 .thenReturn(OidcTokenValidatorResult.valid(SluttBruker.utledBruker("demo"), System.currentTimeMillis() / 1000 + sekunderGjenståendeGyldigTid));
 
         when(idTokenProvider.isOpenAmTokenSoonExpired(any())).thenReturn(true);
-        when(idTokenProvider.refreshOpenAmIdToken(any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, gyldigIdToken)));
+        when(idTokenProvider.refreshOpenAmIdToken(any(), any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, gyldigIdToken)));
 
         AuthStatus result = authModule.validateRequest(request, subject, serviceSubject);
         assertThat(result).isEqualTo(AuthStatus.SUCCESS);
-        verify(idTokenProvider).refreshOpenAmIdToken(any());
+        verify(idTokenProvider).refreshOpenAmIdToken(any(), any());
     }
 
     @Test
@@ -290,7 +290,7 @@ public class OidcAuthModuleTest {
         when(tokenValidator.validate(gyldigIdToken))
                 .thenReturn(OidcTokenValidatorResult.valid(SluttBruker.utledBruker("demo"), System.currentTimeMillis() / 1000 + 60));
         when(idTokenProvider.isOpenAmTokenSoonExpired(any())).thenReturn(true);
-        when(idTokenProvider.refreshOpenAmIdToken(any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, gyldigIdToken)));
+        when(idTokenProvider.refreshOpenAmIdToken(any(), any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, gyldigIdToken)));
 
         AuthStatus result = authModule.validateRequest(request, subject, serviceSubject);
         assertThat(result).isEqualTo(AuthStatus.SEND_CONTINUE);
@@ -313,7 +313,7 @@ public class OidcAuthModuleTest {
         when(tokenValidator.validate(nyttGyldigIdToken))
                 .thenReturn(OidcTokenValidatorResult.valid(SluttBruker.utledBruker("demo"), System.currentTimeMillis() / 1000 + sekunderGjenståendeGyldigTid));
         when(idTokenProvider.isOpenAmTokenSoonExpired(any())).thenReturn(true);
-        when(idTokenProvider.refreshOpenAmIdToken(any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
+        when(idTokenProvider.refreshOpenAmIdToken(any(), any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
 
         authModule.validateRequest(request, subject, serviceSubject);
 
@@ -364,11 +364,11 @@ public class OidcAuthModuleTest {
         when(tokenValidator.validate(nyttGyldigIdToken))
                 .thenReturn(OidcTokenValidatorResult.valid(SluttBruker.utledBruker("demo"), System.currentTimeMillis() / 1000 + 3600));
         when(idTokenProvider.isOpenAmTokenSoonExpired(any())).thenReturn(true);
-        when(idTokenProvider.refreshOpenAmIdToken(any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
+        when(idTokenProvider.refreshOpenAmIdToken(any(), any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
 
         authModule.validateRequest(request, subject, serviceSubject);
 
-        verify(idTokenProvider).refreshOpenAmIdToken(any());
+        verify(idTokenProvider).refreshOpenAmIdToken(any(), any());
 
         Cookie forventetCookie = new Cookie(ID_TOKEN_COOKIE_NAME, nyttGyldigIdToken.token());
         forventetCookie.setSecure(true);
@@ -395,7 +395,7 @@ public class OidcAuthModuleTest {
         when(tokenValidator.validate(nyttGyldigIdToken))
                 .thenReturn(OidcTokenValidatorResult.valid(SluttBruker.utledBruker("demo"), System.currentTimeMillis() / 1000 + 3600));
         when(idTokenProvider.isOpenAmTokenSoonExpired(any())).thenReturn(true);
-        when(idTokenProvider.refreshOpenAmIdToken(any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
+        when(idTokenProvider.refreshOpenAmIdToken(any(), any())).thenReturn(Optional.of(new OpenIDToken(OpenIDProvider.ISSO, nyttGyldigIdToken)));
 
         authModule.validateRequest(request, subject, serviceSubject);
 

--- a/felles/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/oidc/JwtUtilTest.java
+++ b/felles/sikkerhet/src/test/java/no/nav/vedtak/sikkerhet/oidc/JwtUtilTest.java
@@ -36,7 +36,8 @@ public class JwtUtilTest {
          * "foo", "azp": "bar" }
          */
         String jwt = "eyJraWQiOiIxIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2Zvby5iYXIuYWRlby5uby9vcGVuYW0vb2F1dGgyIiwiZXhwIjoxNTI3MjU2NjYxLCJqdGkiOiJJZk9tT1cxbW9oS1ZSdXRGMW4tUWhBIiwiaWF0IjoxNTI3MjUzMDYxLCJzdWIiOiJkZW1vIiwiYXVkIjoiZm9vIiwiYXpwIjoiYmFyIn0.H43gzgXzUvOQoJcsW6V5QuOSzygLWddbZXPUgzFW2bg09W6j3aVncWglNyRb6RGXIJD8YmJJePWP0xZ5FP9u7qEwvowBE_hQFOfbaM4u674sd6hvupZtk1eDLacU38owANwIoQczBcaTb5KZdwyfWGlsXAG_M3G95a6WxyCJo4WBW3HCwESOYvQep76EzTRIjaFgEKWjfaISdLXtUVWF3UJZaGnCxpiebVQaU81IOI3HYvrX3cVrTlM7QSg5wrFwI2yUl-h49qo_ibBbB-rT976gBeEu26RX2OSZxHHUzjcsqUCLfafje2EPv1Qy5wOlDpGcSoLa7AjtauBtin1Nsg";
-        String clientName = JwtUtil.getClientName(jwt);
+        var claims = JwtUtil.getClaims(jwt);
+        String clientName = JwtUtil.getClientName(claims);
 
         assertThat(clientName).isEqualTo("bar");
     }
@@ -49,7 +50,8 @@ public class JwtUtilTest {
          * "foo" }
          */
         String jwt = "eyJraWQiOiIxIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2Zvby5iYXIuYWRlby5uby9vcGVuYW0vb2F1dGgyIiwiZXhwIjoxNTI3MjU2NjYxLCJqdGkiOiJ5enVjX1JkZF82SW1vMi00RXJmQ1R3IiwiaWF0IjoxNTI3MjUzMDYxLCJzdWIiOiJkZW1vIiwiYXVkIjoiZm9vIn0.HbrqyYdrL1JS6c3n_Tr70QCa0bVdHHD0t_vRbFs2_e6fU78dGNGi2KQPdEnmw419aM8Oh-pmdPXito_roG9KX2Nq7PcFJxXhBXhlubfGisFfqzdfwZDZFW4iJl0amLc4nPJ3Yw3O447lGVM_hpUEDRuTJrD18b_Tajp-peinydupXpiFG1vBrR47gmCLg6jhWuBWTsvUV5F20RFUmTlesy47Xw-80xknySJ7QFhEZDOs4SEXpdp5Rdo4VzGdn2ynQysLH0hhxU-yEjYCj9aKliGZteQYW_ZeogkK4rI09XrFLI5WBdOr9XWyavo6QK7Ba9MCmPNBqIguuUbWpc39xA";
-        String clientName = JwtUtil.getClientName(jwt);
+        var claims = JwtUtil.getClaims(jwt);
+        String clientName = JwtUtil.getClientName(claims);
 
         assertThat(clientName).isEqualTo("foo");
     }
@@ -63,7 +65,7 @@ public class JwtUtilTest {
          */
         String jwt = "eyJraWQiOiIxIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2Zvby5iYXIuYWRlby5uby9vcGVuYW0vb2F1dGgyIiwiZXhwIjoxNTI3MjU2NjYxLCJqdGkiOiJkTEQtZHJoeE04eFFVZ0k1ZU1BSlRRIiwiaWF0IjoxNTI3MjUzMDYxLCJzdWIiOiJkZW1vIiwiYXVkIjpbImZvbyIsImJheiJdfQ.UkVLI7ae7o-_z7hde27q1eujCi_eLBjMS7_8NTMw2lNY4xVDBNOGp8LAKMvr41ykCMEqf8fxyI1jBSOOul3P8TODHX6ogrz9ig38qORINGynp8FJ1AbLtGFNyuN1BHJosj8wsGKqILUHGVJ7F2NWLJZ-Bu40AxS4566BC5WsPbQkHIfRr8YYqv6BBk0iirCcarNLW09vEgFN-hkEyPpIIMxuS6AjwNDIS0WbCSWGQ_5y5CzgoWAv5wgfLiOqdSqkx_RGgcIQNtUYtWkHWwvJBgIENAygpPtQAKd3DuJ7WOGR0RIp4AzkyTwlEnHBg3tgK0ieqhMfJdTgyXWWiQOYzg";
 
-        var e = assertThrows(TekniskException.class, () -> JwtUtil.getClientName(jwt));
+        var e = assertThrows(TekniskException.class, () -> JwtUtil.getClientName(JwtUtil.getClaims(jwt)));
         assertTrue(e.getMessage().contains("[foo, baz]"));
         assertTrue(e.getMessage().contains("Kan ikke utlede clientName"));
 

--- a/felles/sikkerhet/src/test/java/no/nav/vedtak/tokenx/TestAssertionGenerator.java
+++ b/felles/sikkerhet/src/test/java/no/nav/vedtak/tokenx/TestAssertionGenerator.java
@@ -1,0 +1,31 @@
+package no.nav.vedtak.tokenx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Instant;
+
+import org.jose4j.jwt.MalformedClaimException;
+import org.junit.jupiter.api.Test;
+
+import no.nav.vedtak.sikkerhet.oidc.JwtUtil;
+import no.nav.vedtak.sikkerhet.oidc.KeyStoreTool;
+
+public class TestAssertionGenerator {
+
+    @Test
+    public void lag_signer_valider_tokenx_assertion() throws MalformedClaimException {
+        var generator = new TokenXAssertionGenerator(URI.create("https://token/endpoint"), "minKlient", KeyStoreTool.getJsonWebKey());
+        var token = generator.assertion();
+
+        var claims = JwtUtil.getClaims(token);
+        assertThat(claims.getClaimValueAsString("iss")).isEqualTo("minKlient");
+        assertThat(claims.getClaimValueAsString("sub")).isEqualTo("minKlient");
+        assertThat(claims.getClaimValueAsString("aud").toString()).contains("https://token/endpoint");
+        assertThat(Instant.ofEpochSecond(claims.getClaimValue("nbf", Long.class))).isBefore(Instant.now());
+        assertThat(Instant.ofEpochSecond(claims.getClaimValue("iat", Long.class))).isBefore(Instant.now());
+        assertThat(Instant.ofEpochSecond(claims.getClaimValue("exp", Long.class))).isAfter(Instant.now());
+
+    }
+
+}


### PR DESCRIPTION
Har studert jose4j vs nimbusds - manifest og import-pom + gjort dependency:tree + testet x-compat -> valgte jose4j
* Vi skal snart over på EE9.1 og vil ha minimalt med rare avhengigheter vi ikke er bevisst på.
* Brian Campbell aka jose4j er aktiv og har minimalt med eksterne avhengigheter + har fulgt opp nimbus
* Vi bruker minimalt med funksjonalitet.
* Begge bibliotekene tilbyr nøyaktig det samme - også henting av jwks (her håper vi jetty blir bra til slutt)