### PR TITLE
Slå på aad aud validation i prod + dev

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
@@ -189,7 +189,7 @@ public final class OidcProviderConfig {
             !ENV.isLocal(), useProxy,
             ENV.getRequiredProperty(AZURE_CLIENT_ID),
             ENV.getProperty(AZURE_CLIENT_SECRET),
-            !ENV.isDev());
+            ENV.isLocal());
     }
 
     private static OpenIDConfiguration createTokenXConfiguration(String wellKnownUrl) {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
@@ -189,7 +189,7 @@ public final class OidcProviderConfig {
             !ENV.isLocal(), useProxy,
             ENV.getRequiredProperty(AZURE_CLIENT_ID),
             ENV.getProperty(AZURE_CLIENT_SECRET),
-            ENV.isLocal());
+            false);
     }
 
     private static OpenIDConfiguration createTokenXConfiguration(String wellKnownUrl) {


### PR DESCRIPTION
Ser greit ut i dev. Kan vi sette den til false også for local og vtp? isLocal() = !dev && !prod