### PR TITLE
Forenkle TokenFlow, fjerne CONTEXT

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -16,26 +16,19 @@ import no.nav.vedtak.sikkerhet.oidc.token.impl.TokenXExchangeKlient;
 
 public final class TokenProvider {
 
-
-    public static OpenIDToken getTokenFor(SikkerhetContext context) {
-        return switch (context) {
-            case BRUKER -> getTokenFraContextFor(OpenIDProvider.ISSO, null, true);
-            case SYSTEM -> getStsSystemToken();
-        };
+    private TokenProvider() {
     }
 
-    public static OpenIDToken getTokenUtenSamlFallback(SikkerhetContext context) {
-        return switch (context) {
-            case BRUKER -> getTokenFraContextFor(OpenIDProvider.ISSO, null, false);
-            case SYSTEM -> getStsSystemToken();
-        };
+    public static OpenIDToken getTokenForSystem() {
+        return getTokenForSystem(OpenIDProvider.STS, null);
     }
 
-    public static OpenIDToken getTokenFor(SikkerhetContext context, OpenIDProvider provider, String scopes) {
-        return switch (context) {
-            case BRUKER -> getTokenFraContextFor(provider, scopes, true);
-            case SYSTEM -> OpenIDProvider.AZUREAD.equals(provider) ? getAzureSystemToken(scopes) : getStsSystemToken();
-        };
+    public static OpenIDToken getTokenXUtenSamlFallback() {
+        return getTokenFraContextFor(OpenIDProvider.TOKENX, null, false);
+    }
+
+    public static OpenIDToken getTokenForSystem(OpenIDProvider provider, String scopes) {
+        return OpenIDProvider.AZUREAD.equals(provider) ? getAzureSystemToken(scopes) : getStsSystemToken();
     }
 
     public static OpenIDToken getTokenFromCurrent(SikkerhetContext context, String scopes) {
@@ -64,15 +57,15 @@ public final class TokenProvider {
         }
     }
 
-    public static OpenIDToken getStsSystemToken() {
+    private static OpenIDToken getStsSystemToken() {
         return StsSystemTokenKlient.hentAccessToken();
     }
 
-    public static OpenIDToken getAzureSystemToken(String scopes) {
+    private static OpenIDToken getAzureSystemToken(String scopes) {
         return AzureSystemTokenKlient.instance().hentAccessToken(scopes);
     }
 
-    public static OpenIDToken veksleAzureAccessToken(OpenIDToken incoming, String scopes) {
+    private static OpenIDToken veksleAzureAccessToken(OpenIDToken incoming, String scopes) {
         var uid = BrukerTokenProvider.getUserId();
         return AzureBrukerTokenKlient.instance().oboExchangeToken(uid, incoming, scopes);
     }
@@ -130,7 +123,7 @@ public final class TokenProvider {
     }
 
     private static OpenIDProvider getProvider(OpenIDToken token) {
-        return Optional.ofNullable(token).map(OpenIDToken::provider).orElse(OpenIDProvider.ISSO);
+        return Optional.ofNullable(token).map(OpenIDToken::provider).orElse(null);
     }
 
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -7,7 +7,6 @@ import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -50,40 +49,6 @@ public class AzureBrukerTokenKlient {
             INSTANCE = inst;
         }
         return inst;
-    }
-
-    public OpenIDToken exhangeAuthCode(String authorizationCode, String callback, String scopes) {
-        String data = "client_id=" + clientId +
-            "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
-            "&code=" + authorizationCode +
-            "&redirect_uri=" + URLEncoder.encode(callback, UTF_8) +
-            "&grant_type=authorization_code" +
-            "&client_secret=" + clientSecret;
-        var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
-        LOG.info("AzureBruker hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
-        return new OpenIDToken(OpenIDProvider.AZUREAD, response.token_type(), new TokenString(response.access_token()),
-            scopes, new TokenString(response.refresh_token()), response.expires_in());
-
-    }
-
-    public Optional<OpenIDToken> refreshIdToken(OpenIDToken expiredToken, String scopes) {
-        if (expiredToken.refreshToken().isEmpty())
-            return Optional.empty();
-        var data = "client_id=" + clientId +
-            "&scope=" + URLEncoder.encode(scopes, StandardCharsets.UTF_8) +
-            "&refresh_token=" + expiredToken.refreshToken().get() +
-            "&grant_type=refresh_token" +
-            "&client_secret=" + clientSecret;
-        var request = lagRequest(data);
-        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
-        LOG.info("AzureBruker hentet og fikk token av type {} utløper {}", response.token_type(), response.expires_in());
-        if (response.token_type() == null || response.expires_in() == null) {
-            return Optional.empty();
-        }
-        var token = new OpenIDToken(OpenIDProvider.AZUREAD, response.token_type(), new TokenString(response.access_token()),
-            scopes, new TokenString(response.refresh_token()), response.expires_in());
-        return Optional.of(token);
     }
 
     public OpenIDToken oboExchangeToken(String uid, OpenIDToken incomingToken, String scopes) {

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/loginmodule/ContainerLogin.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/sikkerhet/loginmodule/ContainerLogin.java
@@ -19,7 +19,6 @@ import no.nav.vedtak.isso.ressurs.TokenCallback;
 import no.nav.vedtak.log.mdc.MDCOperations;
 import no.nav.vedtak.sikkerhet.context.SubjectHandler;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
-import no.nav.vedtak.sikkerhet.oidc.token.SikkerhetContext;
 import no.nav.vedtak.sikkerhet.oidc.token.TokenProvider;
 
 /**
@@ -83,7 +82,7 @@ public class ContainerLogin {
 
     private void ensureWeHaveTokens() {
         if (token == null) {
-            token = TokenProvider.getTokenFor(SikkerhetContext.SYSTEM);
+            token = TokenProvider.getTokenForSystem();
         }
     }
 

--- a/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXchange.java
+++ b/felles/sikkerhet/src/main/java/no/nav/vedtak/tokenx/TokenXchange.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
-import no.nav.vedtak.sikkerhet.oidc.token.SikkerhetContext;
 import no.nav.vedtak.sikkerhet.oidc.token.TokenProvider;
 
 /**
@@ -28,7 +27,7 @@ public final class TokenXchange {
     }
 
     public static OpenIDToken exchange(URI targetEndpoint) {
-        var token = TokenProvider.getTokenUtenSamlFallback(SikkerhetContext.BRUKER);
+        var token = TokenProvider.getTokenXUtenSamlFallback();
         return exchange(token, targetEndpoint);
     }
 

--- a/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/AbstractPersonKlient.java
+++ b/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/AbstractPersonKlient.java
@@ -36,7 +36,7 @@ import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 public abstract class AbstractPersonKlient implements Persondata {
 
-    private static Set<TokenFlow> REQUIRED_TOKEN = Set.of(TokenFlow.ADAPTIVE_ADD_CONSUMER, TokenFlow.CONTEXT_ADD_CONSUMER);
+    private static Set<TokenFlow> REQUIRED_TOKEN = Set.of(TokenFlow.ADAPTIVE_ADD_CONSUMER);
     private static final Logger LOG = LoggerFactory.getLogger(AbstractPersonKlient.class);
 
     private final PdlDefaultErrorHandler errorHandler;

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcContextSupplier.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcContextSupplier.java
@@ -15,8 +15,8 @@ public final class OidcContextSupplier implements RequestContextSupplier {
     }
 
     @Override
-    public Supplier<OpenIDToken> tokenFor(SikkerhetContext context) {
-        return () -> TokenProvider.getTokenFor(context);
+    public Supplier<OpenIDToken> tokenForSystem() {
+        return TokenProvider::getTokenForSystem;
     }
 
     @Override
@@ -25,13 +25,13 @@ public final class OidcContextSupplier implements RequestContextSupplier {
     }
 
     @Override
-    public Supplier<OpenIDToken> azureTokenFor(SikkerhetContext context, String scopes) {
-        return () -> TokenProvider.getTokenFor(context, OpenIDProvider.AZUREAD, scopes);
+    public Supplier<OpenIDToken> azureTokenForSystem(String scopes) {
+        return () -> TokenProvider.getTokenForSystem(OpenIDProvider.AZUREAD, scopes);
     }
 
     @Override
     public Supplier<OpenIDToken> consumerToken() {
-        return () -> TokenProvider.getTokenFor(SikkerhetContext.SYSTEM);
+        return TokenProvider::getTokenForSystem;
     }
 
     @Override

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RequestContextSupplier.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RequestContextSupplier.java
@@ -9,9 +9,9 @@ public interface RequestContextSupplier {
 
     Supplier<String> consumerIdFor(SikkerhetContext context);
 
-    Supplier<OpenIDToken> tokenFor(SikkerhetContext context);
+    Supplier<OpenIDToken> tokenForSystem();
 
-    Supplier<OpenIDToken> azureTokenFor(SikkerhetContext context, String scopes);
+    Supplier<OpenIDToken> azureTokenForSystem(String scopes);
 
     Supplier<OpenIDToken> adaptive(SikkerhetContext context, String scopes);
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientConfig.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClientConfig.java
@@ -19,7 +19,7 @@ public @interface RestClientConfig {
      * Type of token and flow required by the endpoint
      */
     @Nonbinding
-    TokenFlow tokenConfig() default TokenFlow.CONTEXT;
+    TokenFlow tokenConfig() default TokenFlow.ADAPTIVE;
 
     /**
      * Application running in the namespace of Team Foreldrepenger. Implies endpoint (and later on scopes)

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestConfig.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestConfig.java
@@ -36,7 +36,7 @@ public record RestConfig(TokenFlow tokenConfig, URI endpoint, String scopes, URI
     }
 
     private static final Environment ENV = Environment.current();
-    private static final Set<TokenFlow> REQUIRE_SCOPE = Set.of(TokenFlow.AZUREAD_CC, TokenFlow.CONTEXT_AZURE);
+    private static final Set<TokenFlow> REQUIRE_SCOPE = Set.of(TokenFlow.AZUREAD_CC);
 
     private static URI endpointFromAnnotation(RestClientConfig config) {
         return fromAnnotation(config, FpApplication::contextPathFor, RestClientConfig::endpointProperty, RestClientConfig::endpointDefault)

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestRequest.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestRequest.java
@@ -54,7 +54,7 @@ public sealed class RestRequest extends HttpClientRequest permits RestRequestExp
     private static final RequestContextSupplier CONTEXT_SUPPLIER = new OidcContextSupplier();
 
     private RestRequest() {
-        this(HttpRequest.newBuilder(), TokenFlow.CONTEXT, null, CONTEXT_SUPPLIER);
+        this(HttpRequest.newBuilder(), TokenFlow.ADAPTIVE, null, CONTEXT_SUPPLIER);
     }
 
     protected RestRequest(HttpRequest.Builder builder, TokenFlow tokenConfig, String scopes, RequestContextSupplier supplier) {
@@ -65,7 +65,7 @@ public sealed class RestRequest extends HttpClientRequest permits RestRequestExp
         this.authorization(selectTokenSupplier(tokenConfig, scopes, supplier))
             .consumerId(selectConsumerId(tokenConfig, supplier))
             .validator(RestRequest::validateRestHeaders);
-        if (TokenFlow.CONTEXT_ADD_CONSUMER.equals(tokenConfig) || TokenFlow.ADAPTIVE_ADD_CONSUMER.equals(tokenConfig)) {
+        if (TokenFlow.STS_ADD_CONSUMER.equals(tokenConfig) || TokenFlow.ADAPTIVE_ADD_CONSUMER.equals(tokenConfig)) {
             this.consumerToken(supplier, tokenConfig);
         }
     }
@@ -160,10 +160,8 @@ public sealed class RestRequest extends HttpClientRequest permits RestRequestExp
     private static Supplier<OpenIDToken> selectTokenSupplier(TokenFlow tokenConfig, String scopes, RequestContextSupplier contextSupplier) {
         return switch (tokenConfig) {
             case ADAPTIVE, ADAPTIVE_ADD_CONSUMER -> contextSupplier.adaptive(SikkerhetContext.BRUKER, scopes);
-            case CONTEXT, CONTEXT_ADD_CONSUMER -> contextSupplier.tokenFor(SikkerhetContext.BRUKER);
-            case CONTEXT_AZURE -> contextSupplier.azureTokenFor(SikkerhetContext.BRUKER, scopes);
-            case SYSTEM, STS_CC -> contextSupplier.tokenFor(SikkerhetContext.SYSTEM);
-            case AZUREAD_CC -> contextSupplier.azureTokenFor(SikkerhetContext.SYSTEM, scopes);
+            case SYSTEM, STS_CC, STS_ADD_CONSUMER -> contextSupplier.tokenForSystem();
+            case AZUREAD_CC -> contextSupplier.azureTokenForSystem(scopes);
         };
     }
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestRequestExperimental.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestRequestExperimental.java
@@ -8,7 +8,7 @@ import java.net.http.HttpRequest;
 public final class RestRequestExperimental extends RestRequest {
 
     private RestRequestExperimental() {
-        super(HttpRequest.newBuilder(), TokenFlow.CONTEXT, null, new OidcContextSupplier());
+        super(HttpRequest.newBuilder(), TokenFlow.ADAPTIVE, null, new OidcContextSupplier());
     }
 
     public RestRequestExperimental(HttpRequest.Builder builder, TokenFlow tokenConfig, String scopes, RequestContextSupplier supplier) {

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/TokenFlow.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/TokenFlow.java
@@ -7,7 +7,8 @@ public enum TokenFlow {
     SYSTEM, // Current system user
     STS_CC,
     STS_ADD_CONSUMER, // Midlertidig til vi har lagt om AAreg til Azure. Skyldes kontextkall i abakus
-    AZUREAD_CC
+    AZUREAD_CC,
+    NO_AUTH_NEEDED
     ;
 
     // Does the endpoint require an Azure AD token?

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/TokenFlow.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/TokenFlow.java
@@ -3,18 +3,16 @@ package no.nav.vedtak.felles.integrasjon.rest;
 public enum TokenFlow {
     ADAPTIVE, // DWIM for targets accepting both azuread and isso/sts tokens
     ADAPTIVE_ADD_CONSUMER, // DWIM for targets accepting both azuread and isso/sts tokens - adding consumer token
-    CONTEXT, // For targets expecting OpenAm/isso or STS tokens. Will pass on token in current security context
-    CONTEXT_AZURE, // For targets expecting AzureAD tokens. Will check token+subject in context and perform OBO or CC
-    CONTEXT_ADD_CONSUMER, // As CONTEXT but adds consumerToken for system user
     // TOKENX_OBO, not used Requires process of creating assertion, exchanging token, and using the exchanged token
     SYSTEM, // Current system user
     STS_CC,
+    STS_ADD_CONSUMER, // Midlertidig til vi har lagt om AAreg til Azure. Skyldes kontextkall i abakus
     AZUREAD_CC
     ;
 
     // Does the endpoint require an Azure AD token?
     public boolean isAzureAD() {
-        return CONTEXT_AZURE.equals(this) || AZUREAD_CC.equals(this);
+        return AZUREAD_CC.equals(this);
     }
 
     // Does the endpoint require a system client?

--- a/integrasjon/rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/rest/TestRestClientConfig.java
+++ b/integrasjon/rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/rest/TestRestClientConfig.java
@@ -11,7 +11,7 @@ public class TestRestClientConfig {
     @Test
     void testCase_app_med_endpoint_property_uten_verdi() {
         var config = RestConfig.forClient(TestAbakusMedEndpointProperty.class);
-        assertThat(config.tokenConfig()).isEqualTo(TokenFlow.CONTEXT);
+        assertThat(config.tokenConfig()).isEqualTo(TokenFlow.ADAPTIVE);
         assertThat(config.scopes()).isEqualTo(FpApplication.scopesFor(FpApplication.FPABAKUS));
         assertThat(config.fpContextPath()).isEqualTo(URI.create(FpApplication.contextPathFor(FpApplication.FPABAKUS)));
         assertThat(config.endpoint()).isEqualTo(URI.create(FpApplication.contextPathFor(FpApplication.FPABAKUS)));


### PR DESCRIPTION
Skal være safe. Alle bruk av CONTEXT er vekk unntatt ett tilfelle i abakus som må spesialhåndteres STS_ADD_CONSUMER