### PR TITLE
Utvide metrikk med percentil uten histogram

### DIFF
--- a/felles/log/src/main/java/no/nav/vedtak/log/metrics/MetricsUtil.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/metrics/MetricsUtil.java
@@ -38,6 +38,27 @@ public class MetricsUtil {
         return REGISTRY.scrape();
     }
 
+
+    public static void utvidMedMedian(String navn) {
+        utvidMedPercentiler(navn, 0.5);
+    }
+
+    public static void utvidMedPercentiler(String navn, double... percentiles) {
+        globalRegistry.config().meterFilter(new MeterFilter() {
+            @Override
+            public DistributionStatisticConfig configure(Id id, DistributionStatisticConfig config) {
+                if (id.getName().equals(navn)) {
+                    return DistributionStatisticConfig.builder()
+                        .percentilesHistogram(false)
+                        .percentiles(percentiles)
+                        .build()
+                        .merge(config);
+                }
+                return config;
+            }
+        });
+    }
+
     public static void utvidMedHistogram(String navn) {
         utvidMedHistogram(navn, 0.5, 0.95, 0.99);
     }


### PR DESCRIPTION
Ser ut som Timers lager 73 histogrambøtter - som er litt mye med det antallet endepunkt vi har. Dessuten brukes det ikke.
Det holder med kvantiler/persentiler - ofte er median + max + antall det som trengs