### PR TITLE
Input validering regex arbeidsgiver

### DIFF
--- a/felles/util/src/main/java/no/nav/vedtak/util/InputValideringRegex.java
+++ b/felles/util/src/main/java/no/nav/vedtak/util/InputValideringRegex.java
@@ -63,6 +63,14 @@ public class InputValideringRegex {
      */
     public static final String BASE64_RFC4648_URLSAFE_WITH_PADDING = REGEXP_START + ALFABET_ENGELSK + TALL + "\\-_=" + REGEXP_SLUTT;
 
+
+    private static final String ORGNR = "^\\d{9}$";
+    private static final String AKTØR_ID = "^\\d{13}$";
+    /**
+     * Orgnr eller aktørId
+     */
+    public static final String ARBEIDSGIVER = ORGNR + "|" + AKTØR_ID;
+
     private InputValideringRegex() {
         throw new IllegalAccessError("Skal ikke instansieres");
     }

--- a/felles/util/src/test/java/no/nav/vedtak/util/InputValideringRegexTest.java
+++ b/felles/util/src/test/java/no/nav/vedtak/util/InputValideringRegexTest.java
@@ -1,9 +1,6 @@
 package no.nav.vedtak.util;
 
-import static no.nav.vedtak.util.InputValideringRegex.ADRESSE;
-import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
-import static no.nav.vedtak.util.InputValideringRegex.KODEVERK;
-import static no.nav.vedtak.util.InputValideringRegex.NAVN;
+import static no.nav.vedtak.util.InputValideringRegex.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -70,5 +67,20 @@ public class InputValideringRegexTest {
         assertThat("ab0053").matches(KODEVERK);
         assertThat("NB").matches(KODEVERK);
         assertThat("æøåÆØÅ_214").matches(KODEVERK);
+    }
+
+    @Test
+    public void arbeidsgiver_matcher_kun_13_og_9_digits() {
+        assertThat("123456789").matches(ARBEIDSGIVER);
+        assertThat("aaaaaaaaa").doesNotMatch(ARBEIDSGIVER);
+        assertThat("1234567891").doesNotMatch(ARBEIDSGIVER);
+        assertThat("a123456789").doesNotMatch(ARBEIDSGIVER);
+        assertThat("123456789a").doesNotMatch(ARBEIDSGIVER);
+
+        assertThat("1234567890123").matches(ARBEIDSGIVER);
+        assertThat("aaaaaaaaaaaaa").doesNotMatch(ARBEIDSGIVER);
+        assertThat("12345678901234").doesNotMatch(ARBEIDSGIVER);
+        assertThat("a1234567890123").doesNotMatch(ARBEIDSGIVER);
+        assertThat("1234567890123a").doesNotMatch(ARBEIDSGIVER);
     }
 }


### PR DESCRIPTION
ser vi bruker litt ymse halvfeil regexer for arbeidsgivere i fpsak. Like greit å ha de felles her?
Er det andre arbeidsgivere enn 9 og 13 digits??