### PR TITLE
Samme scopes lokalt og for vtp

### DIFF
--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
@@ -61,6 +61,9 @@ public enum FpApplication {
     }
 
     public static String scopesFor(FpApplication application) {
+        if (CLUSTER.isLocal()) {
+            return "api://" + Cluster.VTP.clusterName() + "." + NAMESPACE.getName() + "." + application.name().toLowerCase() + "/.default";
+        }
         return "api://" + CLUSTER.clusterName() + "." + NAMESPACE.getName() + "." + application.name().toLowerCase() + "/.default";
     }
 


### PR DESCRIPTION
Satser på at dette kan funke innenfor og på tvers av Cluster.LOCAL og Cluster.VTP
Så kan vi sanere scopesProperty i fpsak og fpformidling og bare bruke standard