### PR TITLE
Standardiser på namespace foreldrepenger

### DIFF
--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
@@ -24,7 +24,8 @@ public enum FpApplication {
 
     private static final Environment ENV = Environment.current();
     private static final Cluster CLUSTER  = ENV.getCluster();
-    private static final Namespace NAMESPACE = ENV.getNamespace();
+    // FpApplication brukes til å kalle apps i namespace foreldrepenger - ikke riktig å bruke ENV/namespace
+    private static final Namespace FORELDREPENGER = Namespace.of("teamforeldrepenger");
 
     /*
      * Utelatt fpabonnent:8065
@@ -62,12 +63,13 @@ public enum FpApplication {
 
     public static String scopesFor(FpApplication application) {
         if (CLUSTER.isLocal()) {
-            return "api://" + Cluster.VTP.clusterName() + "." + NAMESPACE.getName() + "." + application.name().toLowerCase() + "/.default";
+            return "api://" + Cluster.VTP.clusterName() + "." + FORELDREPENGER.getName() + "." + application.name().toLowerCase() + "/.default";
         }
-        return "api://" + CLUSTER.clusterName() + "." + NAMESPACE.getName() + "." + application.name().toLowerCase() + "/.default";
+        return "api://" + CLUSTER.clusterName() + "." + FORELDREPENGER.getName() + "." + application.name().toLowerCase() + "/.default";
     }
 
     private String contextPathProperty() {
         return this.name() + ".override.url";
     }
+
 }


### PR DESCRIPTION
Det er riktigst å kode inn namespace = TFP og det er unsafe å bruke current namespace (k9tilbake)
Kan fjerne enda mer konfig i autotest