### PR TITLE
Deserialiser med forventet offsetdatetime

### DIFF
--- a/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgave.java
+++ b/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgave.java
@@ -2,8 +2,11 @@ package no.nav.vedtak.felles.integrasjon.oppgave.v1;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Oppgave(Long id,
@@ -22,5 +25,12 @@ public record Oppgave(Long id,
                       Prioritet prioritet,
                       Oppgavestatus status,
                       String beskrivelse,
-                      LocalDateTime opprettetTidspunkt) {
+                      @JsonDeserialize(using = LocalOffsetDateTimeFormatter.class) LocalDateTime opprettetTidspunkt) {
+
+    private static class LocalOffsetDateTimeFormatter extends LocalDateTimeDeserializer {
+        public LocalOffsetDateTimeFormatter() {
+            super(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+    }
+
 }

--- a/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/OppgaveRestTest.java
+++ b/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/OppgaveRestTest.java
@@ -1,0 +1,46 @@
+package no.nav.vedtak.felles.integrasjon.oppgave.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
+
+class OppgaveRestTest {
+
+    private static final ObjectWriter WRITER = DefaultJsonMapper.getObjectMapper().writerWithDefaultPrettyPrinter();
+    private static final ObjectReader READER = DefaultJsonMapper.getObjectMapper().reader();
+
+    private static final String json = """
+        {
+          "id": 357736794,
+          "tildeltEnhetsnr":"1234",
+          "opprettetAvEnhetsnr":"1234",
+          "saksreferanse":"152200771",
+          "aktoerId":"1000000000000",
+          "beskrivelse":"Må behandle sak i VL!",
+          "temagruppe":"FMLI",
+          "tema":"FOR",
+          "behandlingstema":"ab0326",
+          "oppgavetype":"BEH_SAK_VL",
+          "versjon":1,
+          "opprettetAv":"srvengangsstonad",
+          "prioritet":"NORM",
+          "status": "OPPRETTET",
+          "metadata":{},
+          "fristFerdigstillelse":"2023-01-23",
+          "aktivDato":"2023-01-22",
+          "opprettetTidspunkt":"2023-01-22T18:52:45.206+01:00"
+        }
+        """;
+
+    @Test
+    void test_response() throws Exception {
+        var deserialized = DefaultJsonMapper.fromJson(json, Oppgave.class);
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.tildeltEnhetsnr()).isEqualTo("1234");
+    }
+}


### PR DESCRIPTION
Kan dere heller bruke "aktivDato" enn opprettettid ? Så slipper vi denne kustom-håndteringen 