### PR TITLE
Bruk Azure som default

### DIFF
--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Token.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Token.java
@@ -42,16 +42,12 @@ public class Token {
         this.identType = identType;
     }
 
-    public static Token withOidcToken(OpenIDToken token) {
-        return new Token(null, utledTokenType(token), token, null, null);
-    }
-
     public static Token withOidcToken(OpenIDToken token, String brukerId, IdentType identType) {
         return new Token(null, utledTokenType(token), token, brukerId, identType);
     }
 
     public static Token withSamlToken(String token) {
-        return new Token(token, TokenType.SAML, null, null, null);
+        return new Token(token, TokenType.SAML, null, null, IdentType.InternBruker);
     }
 
     public TokenType getTokenType() {

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
@@ -154,7 +154,7 @@ class PepImplTest {
     private BeskyttetRessursAttributter lagBeskyttetRessursAttributter() {
         return BeskyttetRessursAttributter.builder()
             .medUserId(tokenProvider.getUid())
-            .medToken(Token.withOidcToken(BeskyttetRessursInterceptorTest.DUMMY_OPENID_TOKEN))
+            .medToken(Token.withOidcToken(BeskyttetRessursInterceptorTest.DUMMY_OPENID_TOKEN, "TEST", IdentType.InternBruker))
             .medResourceType(ForeldrepengerAttributter.RESOURCE_TYPE_FP_FAGSAK)
             .medActionType(ActionType.READ)
             .medPepId("local-app")
@@ -167,7 +167,7 @@ class PepImplTest {
     private BeskyttetRessursAttributter lagBeskyttetRessursAttributterPip() {
         return BeskyttetRessursAttributter.builder()
             .medUserId(tokenProvider.getUid())
-            .medToken(Token.withOidcToken(BeskyttetRessursInterceptorTest.DUMMY_OPENID_TOKEN))
+            .medToken(Token.withOidcToken(BeskyttetRessursInterceptorTest.DUMMY_OPENID_TOKEN, "TEST", IdentType.InternBruker))
             .medResourceType(RESOURCE_TYPE_INTERNAL_PIP)
             .medActionType(ActionType.READ)
             .medPepId("local-app")

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImplTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/pdp/PdpKlientImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -33,6 +32,7 @@ import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
 import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
 import no.nav.vedtak.sikkerhet.abac.pipdata.PipBehandlingStatus;
 import no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
@@ -73,7 +73,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void kallPdpUtenFnrResourceHvisPersonlisteErTom() {
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacmlresponse.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -88,7 +88,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void kallPdpMedJwtTokenBodyNårIdTokenErJwtToken() {
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacmlresponse.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -103,7 +103,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void kallPdpMedJwtTokenBodyNårIdTokenErTokeXToken() {
-        var idToken = Token.withOidcToken(JWT_TOKENX_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKENX_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacmlresponse.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -118,7 +118,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void kallPdpMedFlereAttributtSettNårPersonlisteStørreEnn1() {
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacml3response.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -141,7 +141,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void kallPdpMedFlereAttributtSettNårPersonlisteStørreEnn2() {
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacmlresponse-array.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -164,7 +164,7 @@ public class PdpKlientImplTest {
 
     @Test
     public void sporingsloggListeSkalHaSammeRekkefølgePåidenterSomXacmlRequest() {
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacml3response.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -265,7 +265,7 @@ public class PdpKlientImplTest {
     @Test
     public void skal_håndtere_blanding_av_fnr_og_aktør_id() {
 
-        var idToken = Token.withOidcToken(JWT_TOKEN);
+        var idToken = Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker);
         var responseWrapper = createResponse("xacml3response.json");
         var captor = ArgumentCaptor.forClass(XacmlRequest.class);
 
@@ -319,7 +319,7 @@ public class PdpKlientImplTest {
         File file = new File(getClass().getClassLoader().getResource("request.json").getFile());
         var target = DefaultJsonMapper.getObjectMapper().readValue(file, XacmlRequest.class);
 
-        var felles = lagBeskyttetRessursAttributter(Token.withOidcToken(JWT_TOKEN), AbacDataAttributter.opprett());
+        var felles = lagBeskyttetRessursAttributter(Token.withOidcToken(JWT_TOKEN, "TEST", IdentType.InternBruker), AbacDataAttributter.opprett());
         var ressurs = AppRessursData.builder()
             .leggTilAktørId("11111")
             .leggTilFødselsnummer("12345678900")

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
@@ -158,7 +158,7 @@ public final class OidcProviderConfig {
             !ENV.isLocal(), useProxy,
             getAzureProperty(AzureProperty.AZURE_APP_CLIENT_ID),
             getAzureProperty(AzureProperty.AZURE_APP_CLIENT_SECRET),
-            false);
+            ENV.isLocal());
     }
 
     private static String getAzureProperty(AzureProperty property) {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -24,7 +24,7 @@ public final class TokenProvider {
     private static final KontekstProvider KONTEKST_PROVIDER = new DefaultRequestKontekstProvider();
     private static final String ENV_CLIENT_ID = Optional.ofNullable(Environment.current().clientId()).orElseGet(() -> Environment.current().application());
     private static final Set<SikkerhetContext> USE_SYSTEM = Set.of(SikkerhetContext.SYSTEM, SikkerhetContext.WSREQUEST);
-    private static final boolean SYSTEM_USE_AZURE = "true".equalsIgnoreCase(Environment.current().getProperty("token.system.use.azure"));
+    private static final boolean SYSTEM_USE_AZURE = !"false".equalsIgnoreCase(Environment.current().getProperty("token.system.use.azure"));
 
     private TokenProvider() {
     }


### PR DESCRIPTION
Nå må man eksplisitt sette token.system.use.azure=false for at tasks skal bruke sts.
Skrur av aud-validering i vtp+local inntil vi har landet et forenklet oppsett.