### PR TITLE
Ett lokalt cluster og støtte for kryss-cluster-ingress

### DIFF
--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
@@ -34,7 +34,7 @@ import no.nav.vedtak.sikkerhet.oidc.token.TokenString;
 @ExtendWith(MockitoExtension.class)
 class PepImplTest {
 
-    private static final String LOCAL_APP = "local:" + Namespace.foreldrepenger().getName() + ":application";
+    private static final String LOCAL_APP = "vtp:" + Namespace.foreldrepenger().getName() + ":application";
 
     private PepImpl pep;
     @Mock

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>0.4.5</version>
+        <version>0.4.6</version>
     </parent>
 
     <artifactId>felles-root</artifactId>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>0.4.5</version>
+                <version>0.4.6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Slå sammen CLuster VTP og LOCAL til kun VTP. 
Utvidet støtte for app.override.url=http://localhost:port/app - der port = "localport" bruker default port
FpApplication støtter kall mellom GCP og FSS (med ingress) men bruke RestClientConfig m/application = FpApplication.<APP>