### PR TITLE
Korrekt url ved bruk av FPApplication fra gcp til fss.

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/config/impl/OidcProviderConfig.java
@@ -121,13 +121,13 @@ public final class OidcProviderConfig {
 
     @SuppressWarnings("unused")
     private static OpenIDConfiguration createAzureAppConfiguration(String wellKnownUrl) {
-        var useProxy = ENV.isLocal() ? null : URI.create(ENV.getProperty(AZURE_HTTP_PROXY, getDefaultProxy()));
+        var proxyUrl = ENV.isFss() ? URI.create(ENV.getProperty(AZURE_HTTP_PROXY, getDefaultProxy())) : null;
         return createConfiguration(OpenIDProvider.AZUREAD, Optional.ofNullable(getAzureProperty(AzureProperty.AZURE_OPENID_CONFIG_ISSUER))
-                .orElseGet(() -> getIssuerFra(wellKnownUrl, useProxy).orElse(null)),
+                .orElseGet(() -> getIssuerFra(wellKnownUrl, proxyUrl).orElse(null)),
             Optional.ofNullable(getAzureProperty(AzureProperty.AZURE_OPENID_CONFIG_JWKS_URI))
-                .orElseGet(() -> getJwksFra(wellKnownUrl, useProxy).orElse(null)),
+                .orElseGet(() -> getJwksFra(wellKnownUrl, proxyUrl).orElse(null)),
             Optional.ofNullable(getAzureProperty(AzureProperty.AZURE_OPENID_CONFIG_TOKEN_ENDPOINT))
-                .orElseGet(() -> getTokenEndpointFra(wellKnownUrl, useProxy).orElse(null)), !ENV.isLocal(), useProxy,
+                .orElseGet(() -> getTokenEndpointFra(wellKnownUrl, proxyUrl).orElse(null)), ENV.isFss(), proxyUrl,
             getAzureProperty(AzureProperty.AZURE_APP_CLIENT_ID), getAzureProperty(AzureProperty.AZURE_APP_CLIENT_SECRET), ENV.isLocal());
     }
 

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/FpApplication.java
@@ -70,7 +70,10 @@ public enum FpApplication {
             if (ENV.isFss()) { // Kaller fra FSS til GCP
                 return prefix + ".intern" + (ENV.isProd() ? "" : ".dev") + ".nav.no/" + appname;
             } else if (ENV.isGcp()) { // Kaller fra GCP til FSS
-                return prefix + clusterForApplication.clusterName() + "-pub.nais.io/" + appname;
+                if (FPSAK.equals(application)) {
+                    return prefix + "-api." + clusterForApplication.clusterName() + "-pub.nais.io/" + appname;
+                }
+                return prefix + "." + clusterForApplication.clusterName() + "-pub.nais.io/" + appname;
             } else {
                 throw new IllegalStateException("Utviklerfeil: Skal ikke komme hit");
             }


### PR DESCRIPTION
Endre til å bruke default for fpsak -> https://github.com/navikt/fp-sak/pull/5721? Da slipper vi å legge inn spesiallogikk. 

Ellers så legger vi inn at vi ikke skal bruke proxy for AzureAD i gcp