### PR TITLE
Opplegg for behandlingsnummer inn til PDL

### DIFF
--- a/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/Persondata.java
+++ b/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/Persondata.java
@@ -66,9 +66,17 @@ public interface Persondata {
 
     List<HentPersonBolkResult> hentPersonBolk(HentPersonBolkQueryRequest q, HentPersonBolkResultResponseProjection p);
 
+    Person hentPerson(Ytelse ytelse, HentPersonQueryRequest q, PersonResponseProjection p);
+
+    Person hentPerson(Ytelse ytelse, HentPersonQueryRequest q, PersonResponseProjection p, boolean ignoreNotFound);
+
+    List<HentPersonBolkResult> hentPersonBolk(Ytelse ytelse, HentPersonBolkQueryRequest q, HentPersonBolkResultResponseProjection p);
+
     GeografiskTilknytning hentGT(HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p);
 
     <T extends GraphQLResult<?>> T query(GraphQLOperationRequest q, GraphQLResponseProjection p, Class<T> clazz);
+
+    <T extends GraphQLResult<?>> T query(Ytelse ytelse, GraphQLOperationRequest q, GraphQLResponseProjection p, Class<T> clazz);
 
     private Optional<String> hentId(String id, IdentGruppe gruppe, boolean ignoreNotFound) {
         var query = new HentIdenterQueryRequest();
@@ -87,4 +95,23 @@ public interface Persondata {
             throw e;
         }
     }
+
+    enum Ytelse { // Persondata innhentes for ytelse. Default = Foreldrepenger
+        // Utelatt TILBAKEKREVING("B323") Bruk aktuell ytelse
+        ENGANGSSTØNAD("B321"),
+        FORELDREPENGER("B271"),
+        SVANGERSKAPSPENGER("B322"),
+        PLEIEPENGER("B249"); // PGA fptilbake
+
+        private final String behandlingsnummer;
+
+        Ytelse(String behandlingsnummer) {
+            this.behandlingsnummer = behandlingsnummer;
+        }
+
+        public String getBehandlingsnummer() {
+            return behandlingsnummer;
+        }
+    }
+
 }


### PR DESCRIPTION
Behandlingskatalogen er oppdatert iht warnings fra pdl-playground for fp-sak
* Instansier 2 eksemplar med Foreldrepenger / Pleiepenger der nødvendig (dvs fptilbake)
* Der man ikke vet ytelse - som i fpabonnent - så bruker man default eller eksplisitt foreldrepenger
* Satser på å ekspandere til å propagere ytelse ned til kallet, men ikke strengt nødvendig.

Bør legge på behandlingsnummer i header også i selvbetjening