### PR TITLE
Teamdokumenthandtering url oppdatering

### DIFF
--- a/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/AbstractDokArkivKlient.java
+++ b/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/AbstractDokArkivKlient.java
@@ -15,7 +15,7 @@ import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 
-// @RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "dokarkiv.base.url", endpointDefault = "http://dokarkiv.default/rest/journalpostapi/v1/journalpost")
+// @RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "dokarkiv.base.url", endpointDefault = "http://dokarkiv.teamdokumenthandtering/rest/journalpostapi/v1/journalpost")
 public class AbstractDokArkivKlient implements DokArkiv {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDokArkivKlient.class);


### PR DESCRIPTION
I NAIS sitt Kubernetes miljø ble det innført overgang fra standard namespace "default" til team namespace "team". Denne endringen påvirket også URL-ene for Kubernetes-tjenesteoppdagelse. Det ble slutt på oppretting av ressurser i default namespace den 29. september 2021.

Tidligere var en vanlig NAIS tjenesteoppdagelses-URL i Kubernetes som følger: "http://app.default/". Her refererte "default" til standardnavneområdet der tjenesten var plassert. Men nå, med innføringen av teamnavneområder, har URL-en blitt endret til "http://app.team/". Dette betyr at "team" erstatter "default" i URL-en og representerer det tilhørende teamet eller prosjektet som tjenesten tilhører.

For å lette denne overgangen ble det manuelt opprettet service redirects i default namespacet.

Vi ser at appen deres har en referanse til en av teamdokumenthandtering sine redirect service adresser. Denne patchen tar ned risiko for at dette skal feile i produksjon ved misforståelser, opprydding eller annet i default namespace til NAIS clusteret.