### PR TITLE
Flytter tilknytt vedlegg klint inn i dokarkiv.

### DIFF
--- a/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/AbstractDokArkivKlient.java
+++ b/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/AbstractDokArkivKlient.java
@@ -3,6 +3,13 @@ package no.nav.vedtak.felles.integrasjon.dokarkiv;
 import java.net.URI;
 
 import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriBuilderException;
+
+import no.nav.vedtak.exception.TekniskException;
+
+import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.TilknyttVedleggRequest;
+
+import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.TilknyttVedleggResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +80,28 @@ public class AbstractDokArkivKlient implements DokArkiv {
         } catch (Exception e) {
             LOG.info("DOKARKIV FERDIGSTILL {} feilet for {}", journalpostId, enhet, e);
             return false;
+        }
+    }
+
+    @Override
+    public void tilknyttVedlegg(TilknyttVedleggRequest request, String journalpostId) {
+        try {
+            var tilknyttPath = String.format("/%s/tilknyttVedlegg", journalpostId);
+            var uri = UriBuilder.fromUri(restConfig.endpoint()).path(tilknyttPath).build();
+
+            var method = new RestRequest.Method(RestRequest.WebMethod.PUT, RestRequest.jsonPublisher(request));
+            var rrequest = RestRequest.newRequest(method, uri, restConfig);
+            var tilknyttVedleggResponse = restKlient.send(rrequest, TilknyttVedleggResponse.class);
+
+            if (!tilknyttVedleggResponse.feiledeDokumenter().isEmpty()) {
+                throw new IllegalStateException(
+                    "Følgende vedlegg feilet " + tilknyttVedleggResponse + " for journalpost " + journalpostId);
+            } else {
+                LOG.info("Vedlegg tilknyttet {} OK", journalpostId);
+            }
+        } catch (UriBuilderException | IllegalArgumentException e) {
+            throw new TekniskException("FPFORMIDLING-156531",
+                String.format("Feil ved oppretting av URI for tilknytning av vedlegg til %s: %s.", journalpostId, request.toString()), e);
         }
     }
 }

--- a/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/DokArkiv.java
+++ b/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/DokArkiv.java
@@ -4,6 +4,7 @@ package no.nav.vedtak.felles.integrasjon.dokarkiv;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OppdaterJournalpostRequest;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OpprettJournalpostRequest;
 import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.OpprettJournalpostResponse;
+import no.nav.vedtak.felles.integrasjon.dokarkiv.dto.TilknyttVedleggRequest;
 
 public interface DokArkiv {
 
@@ -13,4 +14,5 @@ public interface DokArkiv {
 
     boolean oppdaterJournalpost(String journalpostId, OppdaterJournalpostRequest request);
 
+    void tilknyttVedlegg(TilknyttVedleggRequest request, String journalpostId);
 }

--- a/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/dto/TilknyttVedleggRequest.java
+++ b/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/dto/TilknyttVedleggRequest.java
@@ -1,0 +1,12 @@
+package no.nav.vedtak.felles.integrasjon.dokarkiv.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TilknyttVedleggRequest(List<DokumentTilknytt> dokument) {
+
+    public static record DokumentTilknytt(String kildeJournalpostId, String dokumentInfoId) {
+    }
+}

--- a/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/dto/TilknyttVedleggResponse.java
+++ b/integrasjon/dokarkiv-klient/src/main/java/no/nav/vedtak/felles/integrasjon/dokarkiv/dto/TilknyttVedleggResponse.java
@@ -1,0 +1,12 @@
+package no.nav.vedtak.felles.integrasjon.dokarkiv.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TilknyttVedleggResponse(List<FeiletDokument> feiledeDokumenter) {
+
+    public static record FeiletDokument(String kildeJournalpostId, String dokumentInfoId, String arsakKode) {
+    }
+}


### PR DESCRIPTION
Legger den inn her - så får vi sanert dokdist proxy klienten i formidling.