### PR TITLE
Nytt sammensatt navn i EREG v2, fjerne utgått azure-selector

### DIFF
--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/AbstractOrganisasjonKlient.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/AbstractOrganisasjonKlient.java
@@ -9,8 +9,8 @@ import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 
 // Extend og annoter
-//@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "organisasjon.rs.url",
-//  endpointDefault = "https://modapp.adeo.no/ereg/api/v1/organisasjon")
+//@RestClientConfig(tokenConfig = TokenFlow.NO_AUTH_NEEDED, endpointProperty = "organisasjon.rs.url",
+//  endpointDefault = "https://ereg-services.intern.nav.no/api/v2/organisasjon")
 public abstract class AbstractOrganisasjonKlient implements OrgInfo {
 
     private final RestClient restKlient;

--- a/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonEReg.java
+++ b/integrasjon/ereg-klient/src/main/java/no/nav/vedtak/felles/integrasjon/organisasjon/OrganisasjonEReg.java
@@ -34,7 +34,7 @@ public record OrganisasjonEReg(String organisasjonsnummer, OrganisasjonstypeEReg
         return Optional.ofNullable(virksomhetDetaljer()).map(VirksomhetDetaljer::nedleggelsesdato).orElse(null);
     }
 
-    private record Navn(String navnelinje1, String navnelinje2, String navnelinje3, String navnelinje4, String navnelinje5) {
+    private record Navn(String sammensattnavn, String navnelinje1, String navnelinje2, String navnelinje3, String navnelinje4, String navnelinje5) {
 
         private String getNavn() {
             return Stream.of(navnelinje1(), navnelinje2(), navnelinje3(), navnelinje4(), navnelinje5())


### PR DESCRIPTION
EREG v2 kjører i prod-fss uten tokenkrav. Nytt felt sammensattnavn som kan brukes isf getNavn (som er kildedata)

Kommentar for azure-selektor. Bør teste om fjerning av token.system.use.azure=false i abakus knekker k9-verdikjede