### PR TITLE
Oppgave: Sjekke om finnes åpen JFR-oppgave for journalpost

### DIFF
--- a/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/AbstractOppgaveKlient.java
+++ b/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/AbstractOppgaveKlient.java
@@ -51,6 +51,18 @@ public abstract class AbstractOppgaveKlient implements Oppgaver {
         return hentOppgaverFor(aktørId, oppgaveTyper, enhetsNr, limit);
     }
 
+    @Override
+    public List<Oppgave> finnÅpneJournalføringsoppgaverForJournalpost(String journalpostId) {
+        var builder = UriBuilder.fromUri(restConfig.endpoint())
+            .queryParam("tema", AbstractOppgaveKlient.TEMA_FORELDREPENGER)
+            .queryParam("statuskategori", STATUSKATEGORI_AAPEN)
+            .queryParam("oppgavetype", Oppgavetype.JOURNALFØRING.getKode())
+            .queryParam("journalpostId", journalpostId);
+
+        var request = RestRequest.newGET(builder.build(), restConfig).otherCallId(NavHeaders.HEADER_NAV_CORRELATION_ID);
+        return restKlient.send(addCorrelation(request), FinnOppgaveResponse.class).oppgaver();
+    }
+
     private List<Oppgave> hentOppgaverFor(String aktørId, List<String> oppgaveTyper, String tildeltEnhetsnr, String limit) {
         var builder = UriBuilder.fromUri(restConfig.endpoint())
             .queryParam("tema", AbstractOppgaveKlient.TEMA_FORELDREPENGER)

--- a/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgaver.java
+++ b/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgaver.java
@@ -20,6 +20,9 @@ public interface Oppgaver {
     // Øvrige argumenter kan være null, men hvis det ventes mange oppgaver så sett aktør, enhet eller limit
     List<Oppgave> finnÅpneOppgaver(List<String> oppgaveTyper, String aktørId, String enhetsNr, String limit);
 
+    // Henter åpne oppgaver av type Journalføring for angitt journalpostId
+    List<Oppgave> finnÅpneJournalføringsoppgaverForJournalpost(String journalpostId);
+
     void reserverOppgave(String oppgaveId, String saksbehandlerId);
 
     void avreserverOppgave(String oppgaveId);


### PR DESCRIPTION
De doble JFR-oppgavene skyldes at når man løser en FDR-oppgave i Gosys så endres tema på journalpost fra UKJ til FOR (jfr-hendelse og muligens oppgave) + Gosys oppretter en JFR-oppgave 

Denne nye metoden kan brukes i fpfordel sin OpprettGSakOppgaveTask for å sjekke om det allerede finnes en åpen journalføringsoppgave før fordel oppretter. Hvis allerede finnes -> ikke opprett dobbel-oppgave