### PR TITLE
Restklient: Støtte for å returnere responseobjekt

### DIFF
--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/DefaultHttpClient.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/DefaultHttpClient.java
@@ -57,6 +57,21 @@ public final class DefaultHttpClient {
         return ResponseHandler.handleResponse(doSendExpectBytearrayRetry(httpRequest), httpRequest.uri(), Set.of());
     }
 
+    public HttpResponse<String> sendReturnResponse(HttpClientRequest request) {
+        var httpRequest = request.request();
+        return ResponseHandler.handleRawResponse(doSendExpectStringRetry(httpRequest), httpRequest.uri(), Set.of());
+    }
+
+    public HttpResponse<String> sendReturnResponse(HttpClientRequest request, Set<Integer> acceptStatus) {
+        var httpRequest = request.request();
+        return ResponseHandler.handleRawResponse(doSendExpectStringRetry(httpRequest), httpRequest.uri(), acceptStatus);
+    }
+
+    public HttpResponse<byte[]> sendReturnResponseByteArray(HttpClientRequest request) {
+        var httpRequest = request.request();
+        return ResponseHandler.handleRawResponse(doSendExpectBytearrayRetry(httpRequest), httpRequest.uri(), Set.of());
+    }
+
     /**
      * Raw response, not checked for status codes 4nn or 5nn - please ensure that any usage avoids "quiet errors"
      */

--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/ResponseHandler.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/ResponseHandler.java
@@ -27,4 +27,18 @@ final class ResponseHandler {
         throw new IntegrasjonException("F-468817", String.format("Uventet respons %s fra %s", status, endpoint));
     }
 
+    static <W> HttpResponse<W> handleRawResponse(final HttpResponse<W> response, URI endpoint, Set<Integer> acceptStatus) {
+        int status = response.statusCode();
+        if (status == HttpURLConnection.HTTP_NO_CONTENT) {
+            return null;
+        }
+        if ((status >= HttpURLConnection.HTTP_OK && status < HttpURLConnection.HTTP_MULT_CHOICE) || acceptStatus.contains(status)) {
+            return response;
+        }
+        if (status == HttpURLConnection.HTTP_FORBIDDEN) {
+            throw new ManglerTilgangException("F-468816", "Feilet mot " + endpoint);
+        }
+        throw new IntegrasjonException("F-468817", String.format("Uventet respons %s fra %s", status, endpoint));
+    }
+
 }

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClient.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/RestClient.java
@@ -52,6 +52,14 @@ public final class RestClient {
         return httpklient.sendReturnByteArray(request);
     }
 
+    public HttpResponse<String> sendReturnResponseString(RestRequest request) {
+        return httpklient.sendReturnResponse(request);
+    }
+
+    public HttpResponse<byte[]> sendReturnResponseByteArray(RestRequest request) {
+        return httpklient.sendReturnResponseByteArray(request);
+    }
+
     /**
      * Raw response, not checked for status codes 4nn or 5nn - please ensure that any usage avoids "quiet errors"
      */

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/AbstractSafKlient.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/AbstractSafKlient.java
@@ -2,6 +2,7 @@ package no.nav.vedtak.felles.integrasjon.saf;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 
 import javax.ws.rs.core.UriBuilder;
@@ -73,6 +74,19 @@ public abstract class AbstractSafKlient implements Saf {
             .build();
         var request = RestRequest.newGET(path, restConfig);
         var doc = restKlient.sendReturnByteArray(request);
+        return doc;
+    }
+
+    @Override
+    public HttpResponse<byte[]> hentDokumentResponse(HentDokumentQuery q) {
+        var path = UriBuilder.fromUri(restConfig.endpoint())
+            .path(HENTDOKUMENT)
+            .resolveTemplate("journalpostId", q.journalpostId())
+            .resolveTemplate("dokumentInfoId", q.dokumentId())
+            .resolveTemplate("variantFormat", q.variantFormat())
+            .build();
+        var request = RestRequest.newGET(path, restConfig);
+        var doc = restKlient.sendReturnResponseByteArray(request);
         return doc;
     }
 

--- a/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/Saf.java
+++ b/integrasjon/saf-klient/src/main/java/no/nav/vedtak/felles/integrasjon/saf/Saf.java
@@ -1,5 +1,6 @@
 package no.nav.vedtak.felles.integrasjon.saf;
 
+import java.net.http.HttpResponse;
 import java.util.List;
 
 import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLOperationRequest;
@@ -23,6 +24,8 @@ public interface Saf {
     List<Journalpost> hentTilknyttedeJournalposter(TilknyttedeJournalposterQueryRequest query, JournalpostResponseProjection projection);
 
     byte[] hentDokument(HentDokumentQuery q);
+
+    HttpResponse<byte[]> hentDokumentResponse(HentDokumentQuery q);
 
     <T extends GraphQLResult<?>> T query(GraphQLOperationRequest q, GraphQLResponseProjection p, Class<T> clazz);
 


### PR DESCRIPTION
Utvider SAF med metode for å hente dokument med full response slik at Content-Type kan propageres fra kilden ifm hentDokument med image/png + image/jpeg (ikke bare application/pdf)
Utvider med metoder for å returnere HttpResponse<T>, ikke bare T. Disse er "handled" - dvs sjekket for 4nn og 5nn.
Svaret finnes i response.body() mens Content-Type må fiskes ut fra response.headers() 

@espenwaaga du kan jo se om noen av sendReturnUnhandled kan erstattes med disse som er handled ... Men der er det mye kustom feilhåndtering på helg - evt med acceptStatus - brukes i (sak + oppdrag + tilbake) og (abakus + sak) og (formidling)