### PR TITLE
Utvide hentGT med ytelse for behandlingsnummer

### DIFF
--- a/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/AbstractPersonKlient.java
+++ b/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/AbstractPersonKlient.java
@@ -64,7 +64,12 @@ public abstract class AbstractPersonKlient implements Persondata {
 
     @Override
     public GeografiskTilknytning hentGT(HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p) {
-        return query(q, p, HentGeografiskTilknytningQueryResponse.class).hentGeografiskTilknytning();
+        return query(defaultYtelse, q, p, HentGeografiskTilknytningQueryResponse.class).hentGeografiskTilknytning();
+    }
+
+    @Override
+    public GeografiskTilknytning hentGT(Ytelse ytelse, HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p) {
+        return query(ytelse, q, p, HentGeografiskTilknytningQueryResponse.class).hentGeografiskTilknytning();
     }
 
     @Override

--- a/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/Persondata.java
+++ b/integrasjon/person-klient/src/main/java/no/nav/vedtak/felles/integrasjon/person/Persondata.java
@@ -74,6 +74,8 @@ public interface Persondata {
 
     GeografiskTilknytning hentGT(HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p);
 
+    GeografiskTilknytning hentGT(Ytelse ytelse, HentGeografiskTilknytningQueryRequest q, GeografiskTilknytningResponseProjection p);
+
     <T extends GraphQLResult<?>> T query(GraphQLOperationRequest q, GraphQLResponseProjection p, Class<T> clazz);
 
     <T extends GraphQLResult<?>> T query(Ytelse ytelse, GraphQLOperationRequest q, GraphQLResponseProjection p, Class<T> clazz);


### PR DESCRIPTION
PDL klager på et par apps som kaller hentGT uten behandlingsnummer
hentIdenter trenger ikke behandlingsnummer