### PR TITLE
AuthFilter returnerer 401 ved manglende token. Fjerne ubrukte beans

### DIFF
--- a/felles/abac-kontekst/src/main/resources/META-INF/beans.xml
+++ b/felles/abac-kontekst/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/abac/src/main/resources/META-INF/beans.xml
+++ b/felles/abac/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/abac/src/test/resources/META-INF/beans.xml
+++ b/felles/abac/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/auth-filter/src/main/resources/META-INF/beans.xml
+++ b/felles/auth-filter/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/auth-filter/src/test/java/no/nav/vedtak/sikkerhet/jaxrs/AuthenticationFilterDelegateTest.java
+++ b/felles/auth-filter/src/test/java/no/nav/vedtak/sikkerhet/jaxrs/AuthenticationFilterDelegateTest.java
@@ -92,7 +92,7 @@ class AuthenticationFilterDelegateTest {
         try {
             AuthenticationFilterDelegate.validerSettKontekst(ri, request);
         } catch (WebApplicationException e) {
-            assertThat(e.getResponse().getStatus()).isEqualTo(403);
+            assertThat(e.getResponse().getStatus()).isEqualTo(401);
         }
     }
 

--- a/felles/db/src/main/resources/META-INF/beans.xml
+++ b/felles/db/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/klient/src/main/resources/META-INF/beans.xml
+++ b/felles/klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/konfig/src/main/resources/META-INF/beans.xml
+++ b/felles/konfig/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/kontekst/pom.xml
+++ b/felles/kontekst/pom.xml
@@ -16,10 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>no.nav.foreldrepenger.felles</groupId>
             <artifactId>felles-konfig</artifactId>
         </dependency>

--- a/felles/log/src/main/resources/META-INF/beans.xml
+++ b/felles/log/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidator.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidator.java
@@ -149,8 +149,9 @@ public class OidcTokenValidator {
         if (isAzureClientCredentials(claims, subject)) {
             var brukSubject = Optional.ofNullable(JwtUtil.getStringClaim(claims, AzureProperty.AZP_NAME)).orElse(subject);
             // Ta med bakoverkompatibelt navn ettersom azp_name er ganske langt (tabeller / opprettet_av)
-            if (brukSubject.lastIndexOf(':') >= 0) {
-                var appSrvName = "srv" + brukSubject.substring(brukSubject.lastIndexOf(':') + 1);
+            var sisteKolon = brukSubject.lastIndexOf(':');
+            if (sisteKolon >= 0) {
+                var appSrvName = "srv" + brukSubject.substring(sisteKolon + 1);
                 if (appSrvName.length() > 20) {
                     appSrvName = appSrvName.substring(0, 19);
                 }

--- a/felles/oidc/src/main/resources/META-INF/beans.xml
+++ b/felles/oidc/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/oidc/src/test/resources/META-INF/beans.xml
+++ b/felles/oidc/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/sikkerhet/src/main/resources/META-INF/beans.xml
+++ b/felles/sikkerhet/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/sikkerhet/src/test/resources/META-INF/beans.xml
+++ b/felles/sikkerhet/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/testutilities/src/main/resources/META-INF/beans.xml
+++ b/felles/testutilities/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/testutilities/src/test/resources/META-INF/beans.xml
+++ b/felles/testutilities/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/felles/util/src/main/resources/META-INF/beans.xml
+++ b/felles/util/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/felles/util/src/test/resources/META-INF/beans.xml
+++ b/felles/util/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/arbeidsfordeling-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/arbeidsfordeling-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/dokarkiv-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/dokarkiv-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/dokarkiv-klient/src/test/resources/META-INF/beans.xml
+++ b/integrasjon/dokarkiv-klient/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/ereg-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/ereg-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/infotrygd-grunnlag-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/infotrygd-grunnlag-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/infotrygd-grunnlag-klient/src/test/resources/META-INF/beans.xml
+++ b/integrasjon/infotrygd-grunnlag-klient/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/oppgave-rest-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/oppgave-rest-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/person-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/person-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/rest-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/rest-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/rest-klient/src/test/resources/META-INF/beans.xml
+++ b/integrasjon/rest-klient/src/test/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/saf-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/saf-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>

--- a/integrasjon/spokelse-klient/src/main/resources/META-INF/beans.xml
+++ b/integrasjon/spokelse-klient/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0"
-       bean-discovery-mode="annotated">
-</beans>


### PR DESCRIPTION
Store deler av felles er bønne-fri sone - sletter beans.xml som ikke trengs - oppdaterer de andre.
Pluss litt konvensjon oppdaget ifm lokal test av AuthFilterDelegate