### PR TITLE
Får metrikker over konsumenter og typer token som brukes.

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
@@ -1,0 +1,35 @@
+package no.nav.vedtak.sikkerhet.oidc.validator;
+
+import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
+
+import io.micrometer.core.instrument.Counter;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
+
+public class ConsumerMetric {
+
+    private static final Environment ENV = Environment.current();
+    private static final String FORELDREPENGER_KONSUMENTER = "foreldrepenger.konsumenter";
+
+    private ConsumerMetric() {
+    }
+
+    public static void registrer(String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+        counter(konsument, tokenType, identType, acrLevel).increment();
+    }
+    public static void registrer(String konsument, OpenIDProvider tokenType, IdentType identType) {
+            counter(konsument, tokenType, identType, "").increment();
+    }
+
+    private static Counter counter(String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+        return Counter.builder(FORELDREPENGER_KONSUMENTER)
+            .tag("klient", ENV.getClientId().getClientId())
+            .tag("tokenType", tokenType.name())
+            .tag("identYype", identType.name())
+            .tag("konsument", konsument)
+            .tag("acrLevel", acrLevel)
+            .description("Konsument og token brukt.")
+            .register(REGISTRY);
+    }
+}

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
@@ -15,21 +15,24 @@ public class ConsumerMetric {
     private ConsumerMetric() {
     }
 
-    public static void registrer(String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
-        counter(konsument, tokenType, identType, acrLevel).increment();
+    public static void registrer(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+        counter(clientName, konsument, tokenType, identType, acrLevel).increment();
     }
-    public static void registrer(String konsument, OpenIDProvider tokenType, IdentType identType) {
-            counter(konsument, tokenType, identType, "").increment();
+    public static void registrer(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType) {
+        counter(clientName, konsument, tokenType, identType, null).increment();
     }
 
-    private static Counter counter(String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
-        return Counter.builder(FORELDREPENGER_KONSUMENTER)
-            .tag("klient", ENV.getClientId().getClientId())
+    private static Counter counter(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+        var counter = Counter.builder(FORELDREPENGER_KONSUMENTER)
+            .tag("klient", clientName)
             .tag("tokenType", tokenType.name())
             .tag("identYype", identType.name())
             .tag("konsument", konsument)
-            .tag("acrLevel", acrLevel)
-            .description("Konsument og token brukt.")
-            .register(REGISTRY);
+            .description("Konsument og token brukt.");
+
+        if (acrLevel != null) {
+            counter.tag("acrLevel", acrLevel);
+        }
+        return counter.register(REGISTRY);
     }
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/ConsumerMetric.java
@@ -3,28 +3,26 @@ package no.nav.vedtak.sikkerhet.oidc.validator;
 import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
 
 import io.micrometer.core.instrument.Counter;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.oidc.config.OpenIDProvider;
 
 public class ConsumerMetric {
 
-    private static final Environment ENV = Environment.current();
     private static final String FORELDREPENGER_KONSUMENTER = "foreldrepenger.konsumenter";
 
     private ConsumerMetric() {
     }
 
-    public static void registrer(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
-        counter(clientName, konsument, tokenType, identType, acrLevel).increment();
+    public static void registrer(String klientNavn, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+        counter(klientNavn, konsument, tokenType, identType, acrLevel).increment();
     }
-    public static void registrer(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType) {
-        counter(clientName, konsument, tokenType, identType, null).increment();
+    public static void registrer(String klientNavn, String konsument, OpenIDProvider tokenType, IdentType identType) {
+        counter(klientNavn, konsument, tokenType, identType, null).increment();
     }
 
-    private static Counter counter(String clientName, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
+    private static Counter counter(String klientNavn, String konsument, OpenIDProvider tokenType, IdentType identType, String acrLevel) {
         var counter = Counter.builder(FORELDREPENGER_KONSUMENTER)
-            .tag("klient", clientName)
+            .tag("klient", klientNavn)
             .tag("tokenType", tokenType.name())
             .tag("identYype", identType.name())
             .tag("konsument", konsument)

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidator.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidator.java
@@ -128,7 +128,7 @@ public class OidcTokenValidator {
                 return validateTokenX(claims, subject);
             } else {
                 var identType = IdentType.utledIdentType(subject);
-                registrer(subject, provider, identType);
+                registrer(clientName, subject, provider, identType);
                 return OidcTokenValidatorResult.valid(subject, identType, JwtUtil.getExpirationTimeRaw(claims));
             }
         } catch (InvalidJwtException e) {
@@ -151,7 +151,7 @@ public class OidcTokenValidator {
     private OidcTokenValidatorResult validateAzure(JwtClaims claims, String subject) {
         if (isAzureClientCredentials(claims, subject)) {
             var brukSubject = Optional.ofNullable(JwtUtil.getStringClaim(claims, AzureProperty.AZP_NAME)).orElse(subject);
-            registrer(brukSubject, OpenIDProvider.AZUREAD, IdentType.Systemressurs);
+            registrer(clientName, brukSubject, OpenIDProvider.AZUREAD, IdentType.Systemressurs);
             // Ta med bakoverkompatibelt navn ettersom azp_name er ganske langt (tabeller / opprettet_av)
             var sisteKolon = brukSubject.lastIndexOf(':');
             if (sisteKolon >= 0) {
@@ -165,7 +165,7 @@ public class OidcTokenValidator {
             }
         } else {
             var brukSubject = Optional.ofNullable(JwtUtil.getStringClaim(claims, AzureProperty.NAV_IDENT)).orElse(subject);
-            registrer("Saksbehandler", OpenIDProvider.AZUREAD, IdentType.InternBruker);
+            registrer(clientName, "Saksbehandler", OpenIDProvider.AZUREAD, IdentType.InternBruker);
             var grupper = Optional.ofNullable(JwtUtil.getStringListClaim(claims, AzureProperty.GRUPPER))
                     .map(arr -> GroupsProvider.instance().getGroupsFrom(arr))
                     .orElse(Set.of());
@@ -188,7 +188,7 @@ public class OidcTokenValidator {
             return OidcTokenValidatorResult.invalid("TokenX token ikke på nivå 4");
         }
         var brukSubject = Optional.ofNullable(JwtUtil.getStringClaim(claims, PID)).orElse(subject);
-        registrer("Borger", OpenIDProvider.TOKENX, IdentType.EksternBruker, acrClaim);
+        registrer(clientName, "Borger", OpenIDProvider.TOKENX, IdentType.EksternBruker, acrClaim);
         return OidcTokenValidatorResult.valid(brukSubject, IdentType.EksternBruker, JwtUtil.getExpirationTimeRaw(claims));
     }
 


### PR DESCRIPTION
Enkel prometheus counter som teller validerte tokens og fordeler på klient, konsument, tokenType og identType, acrLevel (kun tokenx).

Det blir enklere å identifisere evtl konsumentene som ikke bruker azure mot oss. 