### PR TITLE
Støtte for å legge til auth-token som hentes fra maskinporten

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -71,7 +71,11 @@ public final class TokenProvider {
     }
 
     public static OpenIDToken getTokenForSystem(OpenIDProvider provider, String scopes) {
-        return OpenIDProvider.AZUREAD.equals(provider) ? getAzureSystemToken(scopes) : getStsSystemToken();
+        return switch (provider) {
+            case AZUREAD -> getAzureSystemToken(scopes);
+            case STS -> getStsSystemToken();
+            case TOKENX -> throw new IllegalStateException("Ikke bruk TokenX til kall i systemkontekst");
+        };
     }
 
     // Endre til AzureClientId ved overgang til system = azure

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcContextSupplier.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/OidcContextSupplier.java
@@ -18,20 +18,11 @@ public final class OidcContextSupplier {
         return () -> TokenProvider.getConsumerIdFor(context);
     }
 
-    public Supplier<OpenIDToken> tokenForSystem() {
-        return TokenProvider::getTokenForSystem;
+    public Supplier<OpenIDToken> tokenForSystem(OpenIDProvider provider, String scopes) {
+        return () -> TokenProvider.getTokenForSystem(provider, scopes);
     }
 
     public Supplier<OpenIDToken> adaptive(String scopes) {
         return () -> TokenProvider.getTokenForKontekst(scopes);
     }
-
-    public Supplier<OpenIDToken> azureTokenForSystem(String scopes) {
-        return () -> TokenProvider.getTokenForSystem(OpenIDProvider.AZUREAD, scopes);
-    }
-
-    public Supplier<OpenIDToken> consumerToken() {
-        return TokenProvider::getTokenForSystem;
-    }
-
 }


### PR DESCRIPTION
For å fjerne siste utgående STS (erstatte med direkte kall til brreg)
Liten utvidelse av restrequest så den ene appen som skal hente maskinporten-token kan gjøre det lokalt uten å utvide TokenProvider (vi skal ikke validere innkommende maskinporten)
