### PR TITLE
Expand-fase for å isolere innkommende STS

### DIFF
--- a/felles/auth-filter/src/main/java/no/nav/vedtak/sikkerhet/jaxrs/TillatSTS.java
+++ b/felles/auth-filter/src/main/java/no/nav/vedtak/sikkerhet/jaxrs/TillatSTS.java
@@ -1,20 +1,19 @@
 package no.nav.vedtak.sikkerhet.jaxrs;
 
+import jakarta.ws.rs.NameBinding;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import jakarta.ws.rs.NameBinding;
-
 /*
- * Primært for endepunkt som kalles av plattformen (liveness, prestop, ...)
- * Kan vurdere å legge til TYPE ved behov for å annotere hele interface eller klasser
+ * Brukes i en overgangsfase for å annotere noen få endepunkt som skal tillate innkommende kall med STS
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @NameBinding
-public @interface UtenAutentisering {
+public @interface TillatSTS {
 }


### PR DESCRIPTION
Utvider UtenAutentisering til å tillate annotering på klasse-nivå (TYPE)
Lager først en annotering for de 2-4 metodene som skal tillate STS. 
Når de er rullet ut så kan AuthenticationFilterDelegate forby STS hvis annotering TillatSTS mangler