### PR TITLE
Sjekk at respons i hentToken har statuskode 2xx

### DIFF
--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/GeneriskTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/GeneriskTokenKlient.java
@@ -41,7 +41,7 @@ public class GeneriskTokenKlient {
     public static OidcTokenResponse hentToken(HttpRequest request, URI proxy) {
         try (var client = hentEllerByggHttpClient(proxy)) { // På sikt vurder å bruke en generell klient eller å cache. De er blitt autocloseable
             var response = client.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
-            if (response == null || response.body() == null) {
+            if (response == null || response.body() == null || !responskode2xx(response)) {
                 throw new TekniskException("F-157385", "Kunne ikke hente token");
             }
             return READER.readValue(response.body());
@@ -53,6 +53,11 @@ public class GeneriskTokenKlient {
             Thread.currentThread().interrupt();
             throw new TekniskException("F-432938", "InterruptedException ved henting av token", e);
         }
+    }
+
+    private static boolean responskode2xx(HttpResponse<String> response) {
+        var status = response.statusCode();
+        return status >= 200 && status < 300;
     }
 
     private static HttpClient hentEllerByggHttpClient(URI proxy) {


### PR DESCRIPTION
Ser fp-oversikt sporadisk feiler på deserialisering av body som ser ut til å komme fra nginx fra plattformen (stopper på første token som er "upstream"). Har ikke funnet hva responskoden er i disse tilfellene, men tenker det ikke er i 200-serien. Legger på en sjekk for å gjøre disse tilfellene mindre forvirrende i loggene.