### PR TITLE
Eksponere innkommende token-OID, logge rest-STS

### DIFF
--- a/felles/abac-kontekst/src/main/java/no/nav/foreldrepenger/sikkerhet/abac/KontekstTokenProvider.java
+++ b/felles/abac-kontekst/src/main/java/no/nav/foreldrepenger/sikkerhet/abac/KontekstTokenProvider.java
@@ -25,7 +25,6 @@ public class KontekstTokenProvider implements TokenProvider {
 
     @Override
     public OpenIDToken openIdToken() {
-        var kontekst = PROVIDER.getKontekst();
-        return kontekst instanceof RequestKontekst rk ? rk.getToken() : null;
+        return PROVIDER.getToken();
     }
 }

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/Groups.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/Groups.java
@@ -6,5 +6,8 @@ public enum Groups {
     OVERSTYRER,
     OPPGAVESTYRER,
     VEILEDER,
-    DRIFT
+    DRIFT,
+    FORTROLIG,
+    STRENGTFORTROLIG,
+    SKJERMET
 }

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/GroupsProvider.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/GroupsProvider.java
@@ -19,7 +19,6 @@ public class GroupsProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupsProvider.class);
     private static final String SUFFIX = ".properties";
-    private static final String PREFIX = "groups";
 
     private static GroupsProvider INSTANCE;
 
@@ -88,7 +87,7 @@ public class GroupsProvider {
         if (cluster.isLocal()) {
             return "-vtp";
         }
-        return "-" + (cluster.isProd() ? "prod" : "dev");
+        return cluster.isProd() ? "-prod" : "-dev";
     }
 
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekst.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekst.java
@@ -3,6 +3,7 @@ package no.nav.vedtak.sikkerhet.kontekst;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import no.nav.vedtak.log.mdc.MDCOperations;
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
@@ -10,17 +11,19 @@ import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 public final class RequestKontekst extends BasisKontekst {
 
     private final OpenIDToken token;
+    private UUID oid;
     private final Set<Groups> grupper;
 
-    private RequestKontekst(String uid, String kompaktUid, IdentType identType, String consumerId, OpenIDToken token, Set<Groups> grupper) {
+    private RequestKontekst(String uid, String kompaktUid, IdentType identType, String consumerId, OpenIDToken token, UUID oid, Set<Groups> grupper) {
         super(SikkerhetContext.REQUEST, uid, kompaktUid, identType, consumerId);
         this.token = token;
+        this.oid = oid;
         this.grupper = new HashSet<>(grupper);
     }
 
-    public static RequestKontekst forRequest(String uid, String kompaktUid, IdentType identType, OpenIDToken token, Set<Groups> grupper) {
+    public static RequestKontekst forRequest(String uid, String kompaktUid, IdentType identType, OpenIDToken token, UUID oid, Set<Groups> grupper) {
         var konsumentId = Optional.ofNullable(MDCOperations.getConsumerId()).orElse(uid);
-        return new RequestKontekst(uid, kompaktUid, identType, konsumentId, token, grupper);
+        return new RequestKontekst(uid, kompaktUid, identType, konsumentId, token, oid, grupper);
     }
 
     public OpenIDToken getToken() {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekst.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekst.java
@@ -30,6 +30,10 @@ public final class RequestKontekst extends BasisKontekst {
         return token;
     }
 
+    public UUID getOid() {
+        return oid;
+    }
+
     public Set<Groups> getGrupper() {
         return grupper;
     }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekstProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/kontekst/RequestKontekstProvider.java
@@ -2,10 +2,16 @@ package no.nav.vedtak.sikkerhet.kontekst;
 
 import no.nav.vedtak.sikkerhet.oidc.token.OpenIDToken;
 
+import java.util.UUID;
+
 public interface RequestKontekstProvider extends KontekstProvider {
 
     default OpenIDToken getToken() {
         return getKontekst() instanceof RequestKontekst tk ? tk.getToken() : null;
+    }
+
+    default UUID getOid() {
+        return getKontekst() instanceof RequestKontekst tk ? tk.getOid() : null;
     }
 
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidatorResult.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidatorResult.java
@@ -1,29 +1,30 @@
 package no.nav.vedtak.sikkerhet.oidc.validator;
 
 import java.util.Set;
+import java.util.UUID;
 
 import no.nav.vedtak.sikkerhet.kontekst.Groups;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 
 public record OidcTokenValidatorResult(boolean isValid, String errorMessage, String subject, IdentType identType,
-                                       String compactSubject, Set<Groups> grupper, long expSeconds) {
+                                       String compactSubject, UUID oid, Set<Groups> grupper, long expSeconds) {
 
     private static final String NO_CLAIMS = "Can't get claims from an invalid token";
 
     public static OidcTokenValidatorResult invalid(String errorMessage) {
-        return new OidcTokenValidatorResult(false, errorMessage, null, null, null, Set.of(), 0);
+        return new OidcTokenValidatorResult(false, errorMessage, null, null, null, null, Set.of(), 0);
     }
 
     public static OidcTokenValidatorResult valid(String subject, IdentType identType, long expSeconds) {
-        return new OidcTokenValidatorResult(true, null, subject, identType, subject, Set.of(), expSeconds);
+        return new OidcTokenValidatorResult(true, null, subject, identType, subject, null, Set.of(), expSeconds);
     }
 
-    public static OidcTokenValidatorResult valid(String subject, IdentType identType, Set<Groups> grupper, long expSeconds) {
-        return new OidcTokenValidatorResult(true, null, subject, identType, subject, grupper, expSeconds);
+    public static OidcTokenValidatorResult valid(String subject, IdentType identType, UUID oid, Set<Groups> grupper, long expSeconds) {
+        return new OidcTokenValidatorResult(true, null, subject, identType, subject, oid, grupper, expSeconds);
     }
 
     public static OidcTokenValidatorResult valid(String subject, IdentType identType, String compactSubject, long expSeconds) {
-        return new OidcTokenValidatorResult(true, null, subject, identType, compactSubject, Set.of(), expSeconds);
+        return new OidcTokenValidatorResult(true, null, subject, identType, compactSubject, null, Set.of(), expSeconds);
     }
 
 

--- a/felles/oidc/src/test/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidatorTest.java
+++ b/felles/oidc/src/test/java/no/nav/vedtak/sikkerhet/oidc/validator/OidcTokenValidatorTest.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
 
 import org.jose4j.jwt.NumericDate;
 import org.junit.jupiter.api.AfterEach;
@@ -133,7 +134,9 @@ class OidcTokenValidatorTest {
 
         var langClientId = "klusternavn:langtnamespace:applikasjon";
 
-        var token = new OidcTokenGenerator().withClaim(AzureProperty.AZP_NAME, langClientId).withClaim("oid", "demo") // samme som sub for CC
+        var token = new OidcTokenGenerator().withClaim(AzureProperty.AZP_NAME, langClientId)
+            .withClaim("idtyp", "app")
+            .withClaim("oid", UUID.randomUUID().toString()) // samme som sub for CC
             .createHeaderTokenHolder();
 
         var result = tokenValidator.validate(token);
@@ -150,14 +153,17 @@ class OidcTokenValidatorTest {
         // that its client_id is the Claim Value
 
         var ident = "minident";
+        var oid = UUID.randomUUID();
 
         var token = new OidcTokenGenerator()
             .withClaim(AzureProperty.NAV_IDENT, ident)
+            .withClaim("oid", oid.toString())
             .createHeaderTokenHolder();
 
         OidcTokenValidatorResult result = tokenValidator.validate(token);
         assertValid(result);
         assertThat(result.getSubject()).isEqualTo(ident);
+        assertThat(result.oid()).isEqualTo(oid);
         assertThat(result.grupper()).isEmpty();
         assertThat(result.getCompactSubject()).isEqualTo(ident);
     }
@@ -171,15 +177,18 @@ class OidcTokenValidatorTest {
 
         var ident = "minident";
         var grupper = List.of("saksbehandler", "oppgavestyrer");
+        var oid = UUID.randomUUID();
 
         var token = new OidcTokenGenerator()
             .withClaim(AzureProperty.NAV_IDENT, ident)
             .withGroupsClam(AzureProperty.GRUPPER, grupper)
+            .withClaim("oid", oid.toString())
             .createHeaderTokenHolder();
 
         OidcTokenValidatorResult result = tokenValidator.validate(token);
         assertValid(result);
         assertThat(result.getSubject()).isEqualTo(ident);
+        assertThat(result.oid()).isEqualTo(oid);
         assertThat(result.grupper()).containsAll(List.of(Groups.SAKSBEHANDLER, Groups.OPPGAVESTYRER));
         assertThat(result.getCompactSubject()).isEqualTo(ident);
     }


### PR DESCRIPTION
To formål: Logge rest-STS-bruk + Tilby OID i requestkontekst - settes fra tokenvalidering - brukes i LOS + tilgangskall.