### PR TITLE
Hindrer logging av FNR når Nav-Consumer-Id ikke er satt.

### DIFF
--- a/felles/auth-filter/src/main/java/no/nav/vedtak/sikkerhet/jaxrs/AuthenticationFilterDelegate.java
+++ b/felles/auth-filter/src/main/java/no/nav/vedtak/sikkerhet/jaxrs/AuthenticationFilterDelegate.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.log.mdc.FnrUtils;
 import no.nav.vedtak.log.mdc.MDCOperations;
 import no.nav.vedtak.sikkerhet.kontekst.BasisKontekst;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
@@ -101,7 +102,7 @@ public class AuthenticationFilterDelegate {
     private static void setUserAndConsumerId(String subject) {
         Optional.ofNullable(subject).ifPresent(MDCOperations::putUserId);
         if (MDCOperations.getConsumerId() == null && subject != null) {
-            MDCOperations.putConsumerId(subject);
+            MDCOperations.putConsumerId(FnrUtils.maskFnr(subject));
         }
     }
 

--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/FnrUtils.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/FnrUtils.java
@@ -1,0 +1,14 @@
+package no.nav.vedtak.log.mdc;
+
+public class FnrUtils {
+    private FnrUtils() {
+        // hide construktor
+    }
+
+    public static String maskFnr(String userId) {
+        if (userId.matches("^\\d{11}$")) {
+            return userId.replaceAll("\\d{5}$", "*****");
+        }
+        return userId;
+    }
+}

--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
@@ -1,5 +1,6 @@
 package no.nav.vedtak.log.mdc;
 
+import static no.nav.vedtak.log.mdc.FnrUtils.maskFnr;
 import static org.slf4j.MDC.get;
 import static org.slf4j.MDC.put;
 
@@ -37,9 +38,6 @@ public final class MDCOperations {
      * Bruk NAV_CONSUMER_ID isteden
      */ public static final String MDC_CONSUMER_ID = "consumerId";
 
-    // QName for the callId header
-    public static final QName CALLID_QNAME = new QName("uri:no.nav.applikasjonsrammeverk", MDC_CALL_ID);
-
     private MDCOperations() {
     }
 
@@ -76,13 +74,6 @@ public final class MDCOperations {
     public static void putUserId(String userId) {
         Objects.requireNonNull(userId, "userId can't be null");
         put(NAV_USER_ID, maskFnr(userId));
-    }
-
-    private static String maskFnr(String userId) {
-        if (userId.matches("^\\d{11}$")) {
-            return userId.replaceAll("\\d{5}$", "*****");
-        }
-        return userId;
     }
 
     public static String getUserId() {

--- a/felles/log/src/test/java/no/nav/vedtak/log/mdc/FnrUtilsTest.java
+++ b/felles/log/src/test/java/no/nav/vedtak/log/mdc/FnrUtilsTest.java
@@ -1,0 +1,31 @@
+package no.nav.vedtak.log.mdc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FnrUtilsTest {
+
+    @Test
+    void maskerFnrTest() {
+        var fdato = "122314";
+        var pnr = "55555";
+        var fakeTestFnr = fdato + pnr;
+        var maskertFnr = FnrUtils.maskFnr(fakeTestFnr);
+        assertThat(maskertFnr).isNotBlank().startsWith(fdato).doesNotContain(pnr).endsWith("*****");
+    }
+
+    @Test
+    void ikkeMaskerVanligTekst() {
+        var ikkeFnr = "dev-fss:teamforeldrepenger:fpsak";
+        var ikkeMaskert = FnrUtils.maskFnr(ikkeFnr);
+        assertThat(ikkeMaskert).isEqualTo(ikkeFnr);
+    }
+
+    @Test
+    void ikkeMaskerOrgnr() {
+        var fakeOrgnr9siffer = "123456789";
+        var ikkeMaskert = FnrUtils.maskFnr(fakeOrgnr9siffer);
+        assertThat(ikkeMaskert).isEqualTo(fakeOrgnr9siffer);
+    }
+}


### PR DESCRIPTION
FNR logges når headeren ikke er satt av klientene - om kallet er borger initiert så vil subject inneholde en FNR som uheldig havner i loggen. 