### PR TITLE
Diverse rydding i headere+mdc og retry tokenhenting

### DIFF
--- a/felles/auth-filter/pom.xml
+++ b/felles/auth-filter/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-klient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
             <artifactId>felles-oidc</artifactId>
         </dependency>
         <dependency>

--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/CommonHttpHeaders.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/CommonHttpHeaders.java
@@ -1,0 +1,20 @@
+package no.nav.vedtak.klient.http;
+
+/**
+ * Standard NAV headere som brukes i kommunikasjon mellom Foreldrepenge-applikasjoner.
+ */
+public final class CommonHttpHeaders {
+
+    private CommonHttpHeaders() {
+    }
+
+    // Headere som brukes mellom FP-applikasjoner
+    public static final String HEADER_NAV_CALLID = "Nav-Callid";
+    public static final String HEADER_NAV_CONSUMER_ID = "Nav-Consumer-Id";
+
+    // Alternativ header - trengs for noen utgående tilfelle, trengs ikke internt
+    public static final String HEADER_NAV_LOWER_CALL_ID = "nav-call-id";
+
+    // Alternativ header - trengs for innkommende kall fra søknad inntil videre. Bør fjernes
+    public static final String HEADER_NAV_ALT_CALLID = "Nav-CallId";
+}

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/BasisKontekst.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/BasisKontekst.java
@@ -6,6 +6,9 @@ import no.nav.foreldrepenger.konfig.Environment;
 
 public class BasisKontekst implements Kontekst {
 
+    private static final String APP_PSEUDO_USERID = "srv" + Optional.ofNullable(Environment.current().application()).orElse("local");
+    private static final String APP_CLIENTID = Optional.ofNullable(Environment.current().clientId()).orElse(APP_PSEUDO_USERID);
+
     private final SikkerhetContext context;
     private final String uid;
     private final String kompaktUid;
@@ -52,16 +55,16 @@ public class BasisKontekst implements Kontekst {
 
     // Denne brukes i prosesstask
     public static BasisKontekst forProsesstaskUtenSystembruker() {
-        var username = "srv" + Optional.ofNullable(Environment.current().application()).orElse("local");
-        var konsument = Optional.ofNullable(Environment.current().clientId()).orElse(username);
-        return new BasisKontekst(SikkerhetContext.SYSTEM, username, IdentType.Prosess, konsument);
+        return new BasisKontekst(SikkerhetContext.SYSTEM, APP_PSEUDO_USERID, IdentType.Prosess, APP_CLIENTID);
     }
 
     public static BasisKontekst ikkeAutentisertRequest(String consumerId) {
-        var consumer = Optional.ofNullable(consumerId)
-            .or(() -> Optional.ofNullable(Environment.current().application()).map(a -> "srv" + a))
-            .orElse("srvlocal");
+        var consumer = Optional.ofNullable(consumerId).orElse(APP_PSEUDO_USERID);
         return new BasisKontekst(SikkerhetContext.REQUEST, null, null, consumer);
+    }
+
+    public static String getAppConsumerId() {
+        return APP_CLIENTID;
     }
 
     static BasisKontekst tomKontekst() {

--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/MDCOperations.java
@@ -7,36 +7,22 @@ import static org.slf4j.MDC.put;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.xml.namespace.QName;
-
 import org.slf4j.MDC;
 
 /**
  * Utility-klasse for kommunikasjon med MDC.
  */
 public final class MDCOperations {
-    public static final String HTTP_HEADER_CALL_ID = "Nav-Callid";
-    public static final String HTTP_HEADER_ALT_CALL_ID = "nav-call-id";
-    public static final String HTTP_HEADER_CONSUMER_ID = "Nav-Consumer-Id";
+    @Deprecated(forRemoval = true) // Immediate etter tasks ferdig
+    private static final String NAV_CALL_ID = "Nav-CallId";
+    @Deprecated(forRemoval = true) // Immediate
+    private static final String NAV_USER_ID = "Nav-userId";
+    @Deprecated(forRemoval = true) // Immediate
+    private static final String NAV_CONSUMER_ID = "Nav-ConsumerId";
 
-    public static final String NAV_CALL_ID = "Nav-CallId";
-    public static final String NAV_USER_ID = "Nav-userId";
-    public static final String NAV_CONSUMER_ID = "Nav-ConsumerId";
-
-    @Deprecated
-    /*
-     * Bruk NAV_CALL_ID isteden
-     */ public static final String MDC_CALL_ID = "callId";
-
-    @Deprecated
-    /*
-     * Bruk NAV_USER_ID isteden
-     */ public static final String MDC_USER_ID = "userId";
-
-    @Deprecated
-    /*
-     * Bruk NAV_CONSUMER_ID isteden
-     */ public static final String MDC_CONSUMER_ID = "consumerId";
+    private static final String MDC_CALL_ID = "callId";
+    private static final String MDC_USER_ID = "userId";
+    private static final String MDC_CONSUMER_ID = "consumerId";
 
     private MDCOperations() {
     }
@@ -46,11 +32,11 @@ public final class MDCOperations {
     }
 
     public static void putCallId(String callId) {
-        toMDC(NAV_CALL_ID, callId);
+        toMDC(MDC_CALL_ID, callId);
     }
 
     public static String getCallId() {
-        return Optional.ofNullable(get(NAV_CALL_ID)).orElse(get(MDC_CALL_ID));
+        return Optional.ofNullable(get(MDC_CALL_ID)).orElseGet(() -> get(NAV_CALL_ID));
     }
 
     public static void removeCallId() {
@@ -59,11 +45,11 @@ public final class MDCOperations {
     }
 
     public static void putConsumerId(String consumerId) {
-        toMDC(NAV_CONSUMER_ID, consumerId);
+        toMDC(MDC_CONSUMER_ID, consumerId);
     }
 
     public static String getConsumerId() {
-        return Optional.ofNullable(get(NAV_CONSUMER_ID)).orElse(get(MDC_CONSUMER_ID));
+        return Optional.ofNullable(get(MDC_CONSUMER_ID)).orElseGet(() -> get(NAV_CONSUMER_ID));
     }
 
     public static void removeConsumerId() {
@@ -73,11 +59,11 @@ public final class MDCOperations {
 
     public static void putUserId(String userId) {
         Objects.requireNonNull(userId, "userId can't be null");
-        put(NAV_USER_ID, maskFnr(userId));
+        put(MDC_USER_ID, maskFnr(userId));
     }
 
     public static String getUserId() {
-        return Optional.ofNullable(get(NAV_USER_ID)).orElse(MDC_USER_ID);
+        return Optional.ofNullable(get(MDC_USER_ID)).orElseGet(() -> get(NAV_USER_ID));
     }
 
     public static void removeUserId() {

--- a/felles/log/src/main/java/no/nav/vedtak/log/mdc/MdcExtendedLogContext.java
+++ b/felles/log/src/main/java/no/nav/vedtak/log/mdc/MdcExtendedLogContext.java
@@ -1,39 +1,29 @@
 package no.nav.vedtak.log.mdc;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.slf4j.MDC;
 
 /**
- * {@link MDC} backet parameter som tillater en semi-colon separert liste av
- * sub-keys. Kan dermed legge til og fjerne ekstra-kontekst data dynamisk.
+ * {@link MDC} backed parameter med felles prefix (kan være tom)
  */
 public class MdcExtendedLogContext {
 
     private static final Pattern ILLEGAL_CHARS = Pattern.compile("[\\[\\];=]");
-    private final String paramName;
-    private final String baseFormat;
+    private final String prefix; // May be empty string, but not null
 
-    public MdcExtendedLogContext(String paramName) {
-        Objects.requireNonNull(paramName, "paramName");
-        this.paramName = paramName;
-        this.baseFormat = paramName + "[]";
+    public MdcExtendedLogContext(String prefix) {
+        Objects.requireNonNull(prefix, "paramName");
+        this.prefix = prefix;
     }
 
-    public static MdcExtendedLogContext getContext(String kontekstParamNavn) {
-        return new MdcExtendedLogContext(kontekstParamNavn);
+    public static MdcExtendedLogContext getContext(String kontekstPrefix) {
+        return new MdcExtendedLogContext(kontekstPrefix);
     }
 
     public void add(String key, Object value) {
-        String currentValue = mdcKey();
-        String cleanedValue = removeKeyValue(key, currentValue);
-        String newValue = insertValue(cleanedValue, key, value);
-        MDC.put(paramName, newValue);
+        validateKey(key);
         if (value == null) {
             MDC.remove(paramKey(key));
         } else {
@@ -41,22 +31,14 @@ public class MdcExtendedLogContext {
         }
     }
 
-    private String paramKey(String key) {
-        return paramName + "_" + key;
-    }
-
-    public String getFullText() {
-        return MDC.get(paramName);
-    }
-
-    private String insertValue(String currentValue, String key, Object keyValue) {
+    public void remove(String key) {
         validateKey(key);
-        if (currentValue == null) {
-            currentValue = this.baseFormat;
-        }
-        String val = currentValue.substring(0, currentValue.length() - 1);
-        val = val + (val.endsWith("[") ? "" : ";") + (keyValue == null ? "" : key + "=" + keyValue) + "]";
-        return val;
+        MDC.remove(paramKey(key));
+    }
+
+    public String get(String key) {
+        validateKey(key);
+        return MDC.get(paramKey(key));
     }
 
     private static void validateKey(String key) {
@@ -65,50 +47,8 @@ public class MdcExtendedLogContext {
         }
     }
 
-    public void remove(String key) {
-        validateKey(key);
-        MDC.remove(paramKey(key));
-        String currentValue = mdcKey();
-        if (currentValue == null) {
-            return;
-        }
-        String newValue = removeKeyValue(key, currentValue);
-        MDC.put(paramName, newValue);
+    private String paramKey(String key) {
+        return prefix + "_" + key;
     }
 
-    private String mdcKey() {
-        String currentValue = MDC.get(paramName);
-        return (currentValue != null) ? currentValue : baseFormat;
-    }
-
-    private String removeKeyValue(String key, String orgValue) {
-        if (orgValue == null) {
-            return null;
-        }
-
-        List<String> contentList = splitParts(orgValue);
-
-        int orgSize = contentList.size();
-        for (int i = orgSize; --i >= 0; ) {
-            if (contentList.get(i).startsWith(key + "=")) {
-                contentList.remove(i);
-            }
-        }
-        if (orgSize == contentList.size()) {
-            return orgValue;
-        } else if (contentList.isEmpty()) {
-            return null;
-        } else {
-            return paramName + "[" + String.join(";", contentList) + "]";
-        }
-
-    }
-
-    private List<String> splitParts(String orgValue) {
-        if (orgValue == null) {
-            return Collections.emptyList();
-        }
-        String content = orgValue.substring(paramName.length() + 1, orgValue.length() - 1);
-        return new ArrayList<>(Arrays.asList(content.split(";")));
-    }
 }

--- a/felles/log/src/test/java/no/nav/vedtak/log/util/MdcExtendedLogContextTest.java
+++ b/felles/log/src/test/java/no/nav/vedtak/log/util/MdcExtendedLogContextTest.java
@@ -1,17 +1,16 @@
 package no.nav.vedtak.log.util;
 
-import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
 
 class MdcExtendedLogContextTest {
 
-    private MdcExtendedLogContext context = MdcExtendedLogContext.getContext("prosess");
+    private final MdcExtendedLogContext context = MdcExtendedLogContext.getContext("prosess");
 
     @AfterEach
     void clear() {
@@ -22,21 +21,13 @@ class MdcExtendedLogContextTest {
     void skal_legge_til_ny_verdi() {
 
         context.add("behandling", 1L);
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1]");
+        assertThat(context.get("behandling")).isEqualTo("1");
 
         context.add("fagsak", 2L);
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;fagsak=2]");
+        assertThat(context.get("fagsak")).isEqualTo("2");
 
-        context.add("prosess", 3L);
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;fagsak=2;prosess=3]");
-    }
-
-    @Test
-    void skal_hente_key_part() {
-        context.add("behandling", 1L);
-        context.add("fagsak", 2L);
-        context.add("prosess", 3L);
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;fagsak=2;prosess=3]");
+        context.add("steg", "sistesteg");
+        assertThat(context.get("steg")).isEqualTo("sistesteg");
     }
 
     @Test
@@ -45,50 +36,15 @@ class MdcExtendedLogContextTest {
         context.add("fagsak", 2L);
         context.add("prosess", 3L);
 
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;fagsak=2;prosess=3]");
-
         context.remove("behandling");
-        assertThat(context.getFullText()).isEqualTo("prosess[fagsak=2;prosess=3]");
-
-        context.remove("prosess");
-        assertThat(context.getFullText()).isEqualTo("prosess[fagsak=2]");
+        assertThat(context.get("behandling")).isNull();
 
         context.remove("fagsak");
-        assertThat(context.getFullText()).isNull();
+        assertThat(context.get("fagsak")).isNull();
+
+        context.remove("steg");
+        assertThat(context.get("steg")).isNull();
 
     }
 
-    @Test
-    void skal_fjerne_verdi_i_midten() {
-        context.add("behandling", 1L);
-        context.add("fagsak", 2L);
-        context.add("prosess", 3L);
-
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;fagsak=2;prosess=3]");
-
-        context.remove("fagsak");
-        assertThat(context.getFullText()).isEqualTo("prosess[behandling=1;prosess=3]");
-
-        context.remove("behandling");
-        assertThat(context.getFullText()).isEqualTo("prosess[prosess=3]");
-
-        context.remove("prosess");
-        assertThat(context.getFullText()).isNull();
-
-    }
-
-    @Test
-    void skal_sjekke_ugyldig_key_left_bracket() {
-        assertThrows(IllegalArgumentException.class, () -> context.add("fdss[", 1L));
-    }
-
-    @Test
-    void skal_sjekke_ugyldig_key_right_bracket() {
-        assertThrows(IllegalArgumentException.class, () -> context.add("fd]ss", 1L));
-    }
-
-    @Test
-    void skal_sjekke_ugyldig_key_semicolon() {
-        assertThrows(IllegalArgumentException.class, () -> context.add("fdss;", 1L));
-    }
 }

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/TokenProvider.java
@@ -3,7 +3,7 @@ package no.nav.vedtak.sikkerhet.oidc.token;
 import java.util.Optional;
 import java.util.Set;
 
-import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.sikkerhet.kontekst.BasisKontekst;
 import no.nav.vedtak.sikkerhet.kontekst.DefaultRequestKontekstProvider;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstProvider;
@@ -17,9 +17,6 @@ import no.nav.vedtak.sikkerhet.oidc.token.impl.TokenXExchangeKlient;
 public final class TokenProvider {
 
     private static final KontekstProvider KONTEKST_PROVIDER = new DefaultRequestKontekstProvider();
-    private static final String ENV_CLIENT_ID = Optional.ofNullable(Environment.current().clientId())
-        .or(() -> Optional.ofNullable(Environment.current().application()))
-        .orElse("local");
     private static final Set<SikkerhetContext> USE_SYSTEM = Set.of(SikkerhetContext.SYSTEM);
 
     private TokenProvider() {
@@ -62,7 +59,7 @@ public final class TokenProvider {
     public static String getConsumerIdFor(SikkerhetContext context) {
         return switch (context) {
             case REQUEST -> getCurrentConsumerId();
-            case SYSTEM -> ENV_CLIENT_ID;
+            case SYSTEM -> BasisKontekst.getAppConsumerId();
         };
     }
 

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureBrukerTokenKlient.java
@@ -22,9 +22,11 @@ public class AzureBrukerTokenKlient {
 
     private static final Logger LOG = LoggerFactory.getLogger(AzureBrukerTokenKlient.class);
 
+    private static final int RETRIES = 1; // 1 attempt, the n retries
+
     private static volatile AzureBrukerTokenKlient INSTANCE; // NOSONAR
 
-    private LRUCache<String, OpenIDToken> obocache;
+    private final LRUCache<String, OpenIDToken> obocache;
 
     private final URI tokenEndpoint;
     private final String clientId;
@@ -60,7 +62,7 @@ public class AzureBrukerTokenKlient {
             + "&grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" + "&requested_token_use=on_behalf_of" + "&client_secret=" + clientSecret;
         var request = lagRequest(data);
         LOG.trace("AzureBruker henter token for scope {}", scopes);
-        var response = GeneriskTokenKlient.hentToken(request, azureProxy);
+        var response = GeneriskTokenKlient.hentTokenRetryable(request, azureProxy, RETRIES);
         LOG.trace("AzureBruker fikk token for scope {} utløper {}", scopes, response.expires_in());
         if (response.access_token() == null) {
             LOG.warn("AzureBruker tom respons {}", response);

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/AzureSystemTokenKlient.java
@@ -22,6 +22,8 @@ public class AzureSystemTokenKlient {
 
     private static final Logger LOG = LoggerFactory.getLogger(AzureSystemTokenKlient.class);
 
+    private static final int RETRIES = 1; // 1 attempt, the n retries
+
     private static AzureSystemTokenKlient INSTANCE;
 
     private final URI tokenEndpoint;
@@ -71,7 +73,7 @@ public class AzureSystemTokenKlient {
             .uri(tokenEndpoint)
             .POST(ofFormData(clientId, clientSecret, scope))
             .build();
-        return GeneriskTokenKlient.hentToken(request, proxy);
+        return GeneriskTokenKlient.hentTokenRetryable(request, proxy, RETRIES);
     }
 
     private static HttpRequest.BodyPublisher ofFormData(String clientId, String clientSecret, String scope) {

--- a/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/GeneriskTokenKlient.java
+++ b/felles/oidc/src/main/java/no/nav/vedtak/sikkerhet/oidc/token/impl/GeneriskTokenKlient.java
@@ -38,7 +38,7 @@ public class GeneriskTokenKlient {
     }
 
 
-    public static OidcTokenResponse hentToken(HttpRequest request, URI proxy) {
+    private static OidcTokenResponse hentToken(HttpRequest request, URI proxy) {
         try (var client = hentEllerByggHttpClient(proxy)) { // På sikt vurder å bruke en generell klient eller å cache. De er blitt autocloseable
             var response = client.send(request, HttpResponse.BodyHandlers.ofString(UTF_8));
             if (response == null || response.body() == null || !responskode2xx(response)) {
@@ -63,7 +63,7 @@ public class GeneriskTokenKlient {
     private static HttpClient hentEllerByggHttpClient(URI proxy) {
         return HttpClient.newBuilder()
             .followRedirects(HttpClient.Redirect.NEVER)
-            .connectTimeout(Duration.ofSeconds(15))
+            .connectTimeout(Duration.ofSeconds(7))
             .proxy(ProxyProperty.getProxySelector(proxy))
             .build();
     }

--- a/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/NavHeaders.java
+++ b/integrasjon/rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/rest/NavHeaders.java
@@ -1,5 +1,7 @@
 package no.nav.vedtak.felles.integrasjon.rest;
 
+import no.nav.vedtak.klient.http.CommonHttpHeaders;
+
 /**
  * Standard NAV header names.
  */
@@ -8,17 +10,17 @@ public final class NavHeaders {
     private NavHeaders() {
     }
 
-    // Commonly used call-id not set by default
+    // Commonly used call-id not set by default, but used by some producers
     public static final String HEADER_NAV_CALL_ID = "Nav-Call-Id";
     public static final String HEADER_NAV_CORRELATION_ID = "X-Correlation-ID";
 
-    // Convention to specify person ident
+    // Convention to specify person identifier for som integrations
     public static final String HEADER_NAV_PERSONIDENT = "Nav-Personident";
     public static final String HEADER_NAV_PERSONIDENTER = "Nav-Personidenter";
 
     // Internal: Will be set by RestRequest, no need to set these in clients
-    public static final String HEADER_NAV_CALLID = "Nav-Callid";
-    public static final String HEADER_NAV_LOWER_CALL_ID = "nav-call-id";
-    public static final String HEADER_NAV_CONSUMER_ID = "Nav-Consumer-Id";
+    public static final String HEADER_NAV_CALLID = CommonHttpHeaders.HEADER_NAV_CALLID;
+    public static final String HEADER_NAV_LOWER_CALL_ID = CommonHttpHeaders.HEADER_NAV_LOWER_CALL_ID;
+    public static final String HEADER_NAV_CONSUMER_ID = CommonHttpHeaders.HEADER_NAV_CONSUMER_ID;
 
 }


### PR DESCRIPTION
Flere småting på en gang:
* Kortere timeout + 1 retry av tokenhenting fra Azure. Bør gi færre log-warnings. Skal mulig ned til 5s og opp til 2 retry.
* AuthenticationFilter gjenkjenner både Nav-Callid og Nav-CallId (men ikke Nav-Call-Id - bare i lowercase)
* Flyttet vanlige headere til felles-klient - til bruk både i innkommende filter og utgående klient
* Gjør om MDCOperations til å bruke callId, consumerId og userId - midlertidig overgang til utrulling gjort + tasks ferdig
* Forenkle MDCExtendedLogContext - fjerner prefix[key=val, key=val] - bare prefix_key = value