### PR TITLE
TFP-5924 legger til ansattgruppe historisk

### DIFF
--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppe.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppe.java
@@ -7,7 +7,8 @@ public enum AnsattGruppe {
     OVERSTYRER,
     OPPGAVESTYRER,
     VEILEDER,
-    DRIFTER,
+    HISTORISK,
+    DRIFT,
     FORTROLIG, // Aka Kode7
     STRENGTFORTROLIG, // Aka Kode6
     SKJERMET // Aka EgenAnsatt

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProvider.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProvider.java
@@ -29,7 +29,8 @@ public class AnsattGruppeProvider {
         AnsattGruppe.OVERSTYRER, "gruppe.oid.overstyrer",
         AnsattGruppe.VEILEDER, "gruppe.oid.veileder",
         AnsattGruppe.OPPGAVESTYRER, "gruppe.oid.oppgavestyrer",
-        AnsattGruppe.DRIFTER, "gruppe.oid.drifter",
+        AnsattGruppe.HISTORISK, "gruppe.oid.historisk",
+        AnsattGruppe.DRIFT, "gruppe.oid.drift",
         AnsattGruppe.FORTROLIG, "gruppe.oid.fortrolig",
         AnsattGruppe.STRENGTFORTROLIG, "gruppe.oid.strengtfortrolig",
         AnsattGruppe.SKJERMET, "gruppe.oid.skjermet"

--- a/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-dev.properties
+++ b/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-dev.properties
@@ -3,4 +3,5 @@ gruppe.oid.beslutter=6e31f9db-7e46-409d-809c-143d3863e4f6
 gruppe.oid.overstyrer=542269ee-090b-4017-bbcc-6791580290ac
 gruppe.oid.oppgavestyrer=e6508a2a-2e74-450e-ad24-eb1b2b4625c6
 gruppe.oid.veileder=8cddda87-0a22-4d35-9186-a2c32a6ab450
-gruppe.oid.drifter=f1b82579-c5b5-4617-9673-8ace5ff67f63
+gruppe.oid.historisk=89308218-3512-4e12-9323-d49f1a5bc7ee
+gruppe.oid.drift=f1b82579-c5b5-4617-9673-8ace5ff67f63

--- a/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-prod.properties
+++ b/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-prod.properties
@@ -3,4 +3,5 @@ gruppe.oid.beslutter=237ec744-da1f-455b-a794-b2d59c7ce7ee
 gruppe.oid.overstyrer=8200240e-d76d-4d48-a655-728d1d8c3641
 gruppe.oid.oppgavestyrer=1a59da27-4c55-4a9d-8480-6abd1a856cd2
 gruppe.oid.veileder=77f05833-ebfd-45fb-8be7-88eca8e7418f
-gruppe.oid.drifter=0d226374-4748-4367-a38a-062dcad70034
+gruppe.oid.historisk=e7db9b2a-95df-4856-a84a-4228f6e24af5
+gruppe.oid.drift=0d226374-4748-4367-a38a-062dcad70034

--- a/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-vtp.properties
+++ b/felles/kontekst/src/main/resources/no/nav/vedtak/sikkerhet/kontekst/ansattgruppeprovider-vtp.properties
@@ -3,4 +3,5 @@ gruppe.oid.beslutter=803b1fd5-27a0-46a2-b1b3-7152f44128b4
 gruppe.oid.overstyrer=503f0cae-5bcd-484b-949c-a7e92d712858
 gruppe.oid.oppgavestyrer=d18989ec-5e07-494b-ad96-0c1f0c76de53
 gruppe.oid.veileder=edfe14fe-9a34-4ecb-8840-536ac2bc2818
-gruppe.oid.drifter=89c71f0c-ca57-4e6f-8545-990f9e24c762
+gruppe.oid.historisk=b1479f2c-b0ee-4fdb-bfc1-08c2f3130076
+gruppe.oid.drift=89c71f0c-ca57-4e6f-8545-990f9e24c762

--- a/felles/kontekst/src/test/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProviderEnvTest.java
+++ b/felles/kontekst/src/test/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProviderEnvTest.java
@@ -33,7 +33,7 @@ class AnsattGruppeProviderEnvTest {
         var provider = AnsattGruppeProvider.instance();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER)).isNotNull();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER).toString()).isEqualTo("6e31f9db-7e46-409d-809c-143d3863e4f6");
-        assertThat(provider.getAnsattGruppeFra("89c71f0c-ca57-4e6f-8545-990f9e24c762")).isEqualTo(AnsattGruppe.DRIFTER);
+        assertThat(provider.getAnsattGruppeFra("89c71f0c-ca57-4e6f-8545-990f9e24c762")).isEqualTo(AnsattGruppe.DRIFT);
         var grupper = List.of("eb211c0d-9ca6-467f-8863-9def2cc06fd3", "542269ee-090b-4017-bbcc-6791580290ac");
         assertThat(provider.getAnsattGrupperFraStrings(grupper)).containsAll(Set.of(AnsattGruppe.SAKSBEHANDLER, AnsattGruppe.OVERSTYRER));
 

--- a/felles/kontekst/src/test/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProviderTest.java
+++ b/felles/kontekst/src/test/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProviderTest.java
@@ -16,7 +16,7 @@ class AnsattGruppeProviderTest {
         var provider = AnsattGruppeProvider.instance();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER)).isNotNull();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER).toString()).isEqualTo("803b1fd5-27a0-46a2-b1b3-7152f44128b4");
-        assertThat(provider.getAnsattGruppeFra("89c71f0c-ca57-4e6f-8545-990f9e24c762")).isEqualTo(AnsattGruppe.DRIFTER);
+        assertThat(provider.getAnsattGruppeFra("89c71f0c-ca57-4e6f-8545-990f9e24c762")).isEqualTo(AnsattGruppe.DRIFT);
         var grupper = List.of("eb211c0d-9ca6-467f-8863-9def2cc06fd3", "503f0cae-5bcd-484b-949c-a7e92d712858");
         assertThat(provider.getAnsattGrupperFraStrings(grupper)).containsAll(Set.of(AnsattGruppe.SAKSBEHANDLER, AnsattGruppe.OVERSTYRER));
 
@@ -31,7 +31,7 @@ class AnsattGruppeProviderTest {
         var provider = AnsattGruppeProvider.instance();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER)).isNotNull();
         assertThat(provider.getAnsattGruppeOid(AnsattGruppe.BESLUTTER)).isEqualTo(UUID.fromString("803b1fd5-27a0-46a2-b1b3-7152f44128b4"));
-        assertThat(provider.getAnsattGruppeFra(UUID.fromString("89c71f0c-ca57-4e6f-8545-990f9e24c762"))).isEqualTo(AnsattGruppe.DRIFTER);
+        assertThat(provider.getAnsattGruppeFra(UUID.fromString("89c71f0c-ca57-4e6f-8545-990f9e24c762"))).isEqualTo(AnsattGruppe.DRIFT);
         var grupper = List.of(UUID.fromString("eb211c0d-9ca6-467f-8863-9def2cc06fd3"), UUID.fromString("503f0cae-5bcd-484b-949c-a7e92d712858"));
         assertThat(provider.getAnsattGrupperFra(grupper)).containsAll(Set.of(AnsattGruppe.SAKSBEHANDLER, AnsattGruppe.OVERSTYRER));
 


### PR DESCRIPTION
Ny gruppe for å kunne slå opp historiske saker (foreløpig kun for søk i Infotrygd). Mer utover i 2025.