### PR TITLE
Nye policynavn fra abac

### DIFF
--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/pdp/xacml/XacmlResponseMapper.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/pdp/xacml/XacmlResponseMapper.java
@@ -52,6 +52,10 @@ public final class XacmlResponseMapper {
             case "fp3_behandle_egen_ansatt" -> Optional.of(Advice.DENY_EGEN_ANSATT);
             case "fp2_behandle_kode7" -> Optional.of(Advice.DENY_KODE_7);
             case "fp1_behandle_kode6" -> Optional.of(Advice.DENY_KODE_6);
+            case "skjermede_navansatte_og_familiemedlemmer" -> Optional.of(Advice.DENY_EGEN_ANSATT);
+            case "adressebeskyttelse_fortrolig_adresse" -> Optional.of(Advice.DENY_KODE_7);
+            case "adressebeskyttelse_strengt_fortrolig_adresse" -> Optional.of(Advice.DENY_KODE_6);
+            case "adressebeskyttelse_strengt_fortrolig_adresse_utland" -> Optional.of(Advice.DENY_KODE_6);
             default -> Optional.empty();
         };
     }


### PR DESCRIPTION
Korrekte navn fra abac-policies. Vi har kjørt lenge med gamle/feil verdier for deny_policy