### PR TITLE
TFP-5966 fjerne ressurstype risikoklassifisering

### DIFF
--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/beskyttet/ResourceType.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/beskyttet/ResourceType.java
@@ -5,7 +5,6 @@ import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESO
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_DRIFT;
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_FAGSAK;
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_OPPGAVESTYRING;
-import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_RISIKOKLASSIFISERING;
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_UTTAKSPLAN;
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_FP_VENTEFRIST;
 import static no.nav.vedtak.sikkerhet.abac.policy.ForeldrepengerAttributter.RESOURCE_TYPE_INTERNAL_PIP;
@@ -21,8 +20,7 @@ public enum ResourceType {
     OPPGAVESTYRING_AVDELINGENHET(RESOURCE_TYPE_FP_AVDELINGENHET),
     OPPGAVESTYRING(RESOURCE_TYPE_FP_OPPGAVESTYRING),
     // OPPGAVEKØ(RESOURCE_TYPE_FP_OPPGAVEKØ), TODO: Vurder om skal brukes for å lese oppgaver for LOS. Nå brukes FAGSAK
-    // Risk
-    RISIKOKLASSIFISERING(RESOURCE_TYPE_FP_RISIKOKLASSIFISERING),
+
     // Selvbetjening
     UTTAKSPLAN(RESOURCE_TYPE_FP_UTTAKSPLAN),
 

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/ForeldrepengerAttributter.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/ForeldrepengerAttributter.java
@@ -50,7 +50,6 @@ public class ForeldrepengerAttributter {
     public static final String RESOURCE_TYPE_FP_AVDELINGENHET = "no.nav.abac.attributter.foreldrepenger.oppgavestyring.avdelingsenhet";
     // public static final String RESOURCE_TYPE_FP_OPPGAVEKØ = "no.nav.abac.attributter.foreldrepenger.oppgaveko"; TODO: Vurder om skal brukes for å lese oppgaver for LOS. Nå brukes FAGSAK. Evt bruk som dataAttributt.
     public static final String RESOURCE_TYPE_FP_OPPGAVESTYRING = "no.nav.abac.attributter.foreldrepenger.oppgavestyring";
-    public static final String RESOURCE_TYPE_FP_RISIKOKLASSIFISERING = "no.nav.abac.attributter.foreldrepenger.risikoklassifisering";
     public static final String RESOURCE_TYPE_FP_UTTAKSPLAN = "no.nav.abac.attributter.resource.foreldrepenger.uttaksplan";
 
     /**

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerPolicies.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerPolicies.java
@@ -37,7 +37,6 @@ public class InternBrukerPolicies {
             case ResourceType.VENTEFRIST -> ventefristPolicy(beskyttetRessursAttributter);
             case ResourceType.OPPGAVESTYRING_AVDELINGENHET -> avdelingEnhetPolicy(appRessursData);
             case ResourceType.OPPGAVESTYRING -> oppgavestyrerPolicy();
-            case ResourceType.RISIKOKLASSIFISERING -> erVeilederEllerSaksbehandler(beskyttetRessursAttributter);
             default ->  Tilgangsvurdering.avslåGenerell("InternBruker har ikke tilgang til ressurs " + beskyttetRessursAttributter.getResourceType());
         };
     }

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -94,7 +94,7 @@ class PepImplTest {
     void skal_gi_tilgang_for_intern_azure_cc() {
         var token = new OpenIDToken(OpenIDProvider.AZUREAD, new TokenString("token"));
         when(tokenProvider.getUid()).thenReturn(LOCAL_APP);
-        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token, LOCAL_APP, IdentType.Systemressurs);
+        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token, IdentType.Systemressurs);
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
@@ -108,7 +108,7 @@ class PepImplTest {
     void skal_gi_avslag_for_ekstern_azure_cc() {
         var token = new OpenIDToken(OpenIDProvider.AZUREAD, new TokenString("token"));
         when(tokenProvider.getUid()).thenReturn("vtp:annetnamespace:ukjentapplication");
-        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token, "vtp:annetnamespace:ukjentapplication",
+        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token,
             IdentType.Systemressurs);
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
@@ -123,7 +123,7 @@ class PepImplTest {
     void skal_gi_avslag_for_godkjent_ekstern_azure_cc_men_i_feil_klusterklasse() {
         var token = new OpenIDToken(OpenIDProvider.AZUREAD, new TokenString("token"));
         when(tokenProvider.getUid()).thenReturn("dev-fss:annetnamespace:eksternapplication");
-        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token, "vtp:annetnamespace:eksternapplication",
+        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.INTERNAL, token,
             IdentType.Systemressurs);
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
@@ -139,7 +139,7 @@ class PepImplTest {
     void skal_gi_tilgang_for_godkjent_ekstern_azure_cc() {
         var token = new OpenIDToken(OpenIDProvider.AZUREAD, new TokenString("token"));
         when(tokenProvider.getUid()).thenReturn("vtp:annetnamespace:eksternapplication");
-        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.ALL, token, "vtp:annetnamespace:eksternapplication",
+        var attributter = lagBeskyttetRessursAttributterAzure(AvailabilityType.ALL, token,
             IdentType.Systemressurs);
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
@@ -194,7 +194,6 @@ class PepImplTest {
 
     private BeskyttetRessursAttributter lagBeskyttetRessursAttributterAzure(AvailabilityType availabilityType,
                                                                             OpenIDToken token,
-                                                                            String brukerId,
                                                                             IdentType identType) {
         return BeskyttetRessursAttributter.builder()
             .medBrukerId(tokenProvider.getUid())

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/EksternBrukerTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/EksternBrukerTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac.policy;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerFagsakTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerFagsakTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac.policy;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import java.util.UUID;
@@ -37,7 +37,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -76,7 +76,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -89,7 +89,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -101,7 +101,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -114,7 +114,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -140,7 +140,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -154,7 +154,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.BESLUTTER)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.BESLUTTER);
     }
 
     @Test
@@ -182,7 +182,7 @@ class InternBrukerFagsakTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OVERSTYRER)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OVERSTYRER);
     }
 
     @Test

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/InternBrukerTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac.policy;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import java.util.UUID;
@@ -29,7 +29,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -55,7 +55,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.DRIFT)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.DRIFT);
     }
 
     @Test
@@ -64,7 +64,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.DRIFT)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.DRIFT);
     }
 
     @Test
@@ -89,7 +89,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
     @Test
@@ -98,34 +98,9 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
+        assertThat(resultat.kreverGrupper()).isEmpty();
     }
 
-    @Test
-    void tilgang_risiko_read() {
-        var attributter = lagAttributter(AnsattGruppe.VEILEDER, ActionType.READ, ResourceType.RISIKOKLASSIFISERING);
-
-        var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
-        assertThat(resultat.fikkTilgang()).isTrue();
-    }
-
-    @Test
-    void tilgang_risiko_create() {
-        var attributter = lagAttributter(AnsattGruppe.SAKSBEHANDLER, ActionType.CREATE, ResourceType.RISIKOKLASSIFISERING);
-
-        var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
-        assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
-    }
-
-    @Test
-    void tilgang_risiko_update() {
-        var attributter = lagAttributter(AnsattGruppe.VEILEDER, ActionType.UPDATE, ResourceType.RISIKOKLASSIFISERING);
-
-        var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
-        assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().isEmpty()).isTrue();
-    }
 
     @Test
     void tilgang_oppgavestyrer_read() {
@@ -133,7 +108,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OPPGAVESTYRER)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OPPGAVESTYRER);
     }
 
     @Test
@@ -142,7 +117,7 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, AppRessursData.builder().build());
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OPPGAVESTYRER)).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OPPGAVESTYRER);
     }
 
 
@@ -153,8 +128,8 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OPPGAVESTYRER)).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.STRENGTFORTROLIG)).isFalse();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OPPGAVESTYRER);
+        assertThat(resultat.kreverGrupper()).doesNotContain(AnsattGruppe.STRENGTFORTROLIG);
     }
 
     @Test
@@ -164,8 +139,8 @@ class InternBrukerTest {
 
         var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
         assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OPPGAVESTYRER)).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.STRENGTFORTROLIG)).isFalse();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OPPGAVESTYRER);
+        assertThat(resultat.kreverGrupper()).doesNotContain(AnsattGruppe.STRENGTFORTROLIG);
     }
 
     @Test
@@ -173,9 +148,10 @@ class InternBrukerTest {
         var attributter = lagAttributter(AnsattGruppe.SAKSBEHANDLER, ActionType.UPDATE, ResourceType.OPPGAVESTYRING_AVDELINGENHET);
         var ressurs = AppRessursData.builder().leggTilRessurs(ForeldrepengerDataKeys.AVDELING_ENHET, "2103").build();
 
-        var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);assertThat(resultat.fikkTilgang()).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.OPPGAVESTYRER)).isTrue();
-        assertThat(resultat.kreverGrupper().contains(AnsattGruppe.STRENGTFORTROLIG)).isTrue();
+        var resultat = InternBrukerPolicies.vurderTilgang(attributter, ressurs);
+        assertThat(resultat.fikkTilgang()).isTrue();
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.OPPGAVESTYRER);
+        assertThat(resultat.kreverGrupper()).contains(AnsattGruppe.STRENGTFORTROLIG);
     }
 
 

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/SystemressursTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/policy/SystemressursTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.sikkerhet.abac.policy;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/felles/db/src/test/java/no/nav/vedtak/felles/jpa/converters/BooleanToStringConverterTest.java
+++ b/felles/db/src/test/java/no/nav/vedtak/felles/jpa/converters/BooleanToStringConverterTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.felles.jpa.converters;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +35,7 @@ class BooleanToStringConverterTest {
 
     @Test
     void skal_konverte_null_boolean_til_null_streng() {
-        assertThat(BOOLEAN_TO_STRING_CONVERTER.convertToDatabaseColumn(null)).isEqualTo(null);
+        assertThat(BOOLEAN_TO_STRING_CONVERTER.convertToDatabaseColumn(null)).isNull();
     }
 
 }

--- a/felles/db/src/test/java/no/nav/vedtak/felles/jpa/converters/PropertiesToStringConverterTest.java
+++ b/felles/db/src/test/java/no/nav/vedtak/felles/jpa/converters/PropertiesToStringConverterTest.java
@@ -1,6 +1,6 @@
 package no.nav.vedtak.felles.jpa.converters;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Properties;


### PR DESCRIPTION
Denne er ikke i bruk lenger og policy er regnet som risikabelt - alt er lov - selv for de som normalt kun har lesetilgang.
Dessuten en del rundt test + sonar.