### PR TITLE
TFP-5952 flytt auditlogging til PEP

### DIFF
--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacResultat.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacResultat.java
@@ -6,4 +6,8 @@ public enum AbacResultat {
     AVSLÅTT_KODE_6,
     AVSLÅTT_EGEN_ANSATT,
     AVSLÅTT_ANNEN_ÅRSAK;
+
+    public boolean fikkTilgang() {
+        return this == GODKJENT;
+    }
 }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Pep.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Pep.java
@@ -5,7 +5,7 @@ import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
 
 public interface Pep {
 
-    Tilgangsbeslutning vurderTilgang(BeskyttetRessursAttributter beskyttetRessursAttributter);
+    AbacResultat vurderTilgang(BeskyttetRessursAttributter beskyttetRessursAttributter);
 
     default String pepId() {
         return Environment.current().getNaisAppName();

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Tilgangsbeslutning.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/Tilgangsbeslutning.java
@@ -6,8 +6,4 @@ import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
 public record Tilgangsbeslutning(AbacResultat beslutningKode,
                                  BeskyttetRessursAttributter beskyttetRessursAttributter,
                                  AppRessursData appRessursData) {
-
-    public boolean fikkTilgang() {
-        return beslutningKode == AbacResultat.GODKJENT;
-    }
 }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/internal/BeskyttetRessursAttributter.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/internal/BeskyttetRessursAttributter.java
@@ -19,13 +19,14 @@ public class BeskyttetRessursAttributter {
     private String brukerId;
     private UUID brukerOid;
     private IdentType identType;
-    private Set<AnsattGruppe> ansattGrupper = new LinkedHashSet<>();
+    private final Set<AnsattGruppe> ansattGrupper = new LinkedHashSet<>();
     private ActionType actionType;
     private ResourceType resourceType;
     private AvailabilityType availabilityType;
     private Token token;
     private String pepId;
     private String servicePath;
+    private boolean sporingslogg = true;
     private AbacDataAttributter dataAttributter;
 
     public static Builder builder() {
@@ -58,6 +59,10 @@ public class BeskyttetRessursAttributter {
 
     public ResourceType getResourceType() {
         return resourceType;
+    }
+
+    public boolean isSporingslogg() {
+        return sporingslogg;
     }
 
     public Token getToken() {
@@ -126,6 +131,11 @@ public class BeskyttetRessursAttributter {
 
         public Builder medResourceType(ResourceType resourceType) {
             pdpRequest.resourceType = resourceType;
+            return this;
+        }
+
+        public Builder medSporingslogg(boolean sporingslogg) {
+            pdpRequest.sporingslogg = sporingslogg;
             return this;
         }
 

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
@@ -49,7 +49,7 @@ class AbacAuditLoggerTest {
 
         abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
         assertGotPattern(auditlogger,
-            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=no.nav.abac.attributter.foreldrepenger.fagsak suid=A000000");
     }
 
     @Test
@@ -65,7 +65,7 @@ class AbacAuditLoggerTest {
         abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
 
         assertGotPattern(auditlogger,
-            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ flexString2=1234 flexString2Label=Behandling request=/foo/behandling_id_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ flexString2=1234 flexString2Label=Behandling request=/foo/behandling_id_in requestContext=no.nav.abac.attributter.foreldrepenger.fagsak suid=A000000");
     }
 
     @Test
@@ -96,7 +96,7 @@ class AbacAuditLoggerTest {
         abacAuditlogger.loggUtfall(AbacResultat.AVSLÅTT_KODE_6, beskyttetRessursAttributter, appRessursData);
 
         assertGotPattern(auditlogger,
-            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|WARN|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|WARN|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=no.nav.abac.attributter.foreldrepenger.fagsak suid=A000000");
     }
 
 
@@ -144,19 +144,19 @@ class AbacAuditLoggerTest {
     @Path("foo")
     static class RestClass {
 
-        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP)
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK)
         @Path("aktoer_in")
         public void aktoerIn(@SuppressWarnings("unused") AktørDto param) {
             // Test
         }
 
-        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP)
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK)
         @Path("behandling_id_in")
         public void behandlingIdIn(@SuppressWarnings("unused") BehandlingIdDto param) {
             // Test
         }
 
-        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP, sporingslogg = false)
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
         @Path("uten_sporingslogg")
         public void utenSporingslogg(@SuppressWarnings("unused") BehandlingIdDto param) {
             // Test

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
@@ -1,0 +1,183 @@
+package no.nav.vedtak.sikkerhet.abac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import jakarta.ws.rs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.vedtak.log.audit.Auditdata;
+import no.nav.vedtak.log.audit.Auditlogger;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
+import no.nav.vedtak.sikkerhet.abac.internal.ActionUthenter;
+import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursAttributter;
+import no.nav.vedtak.sikkerhet.abac.internal.BeskyttetRessursInterceptorTest;
+import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
+import no.nav.vedtak.sikkerhet.kontekst.IdentType;
+
+@ExtendWith(MockitoExtension.class)
+class AbacAuditLoggerTest {
+
+    private final AktørDto aktør1 = new AktørDto("00000000000");
+    private final BehandlingIdDto behandlingIdDto = new BehandlingIdDto(1234L);
+
+    private final ArgumentCaptor<Auditdata> auditdataCaptor = ArgumentCaptor.forClass(Auditdata.class);
+
+    @Test
+    void auditlogg_skal_logge_parametre_som_går_til_pdp_til_sporingslogg_ved_permit() throws Exception {
+        final var auditlogger = mockAuditLogger();
+        final var abacAuditlogger = new AbacAuditlogger(auditlogger);
+
+        var method = RestClass.class.getMethod("aktoerIn", AktørDto.class);
+        var appRessursData = AppRessursData.builder().leggTilAktørId(aktør1.aktørId()).build();
+        var beskyttetRessursAttributter = getBeskyttetRessursAttributter(method,
+            BeskyttetRessursInterceptor.finnAbacDataAttributter(method, new Object[]{aktør1}));
+
+        abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
+        assertGotPattern(auditlogger,
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+    }
+
+    @Test
+    void auditlogg_skal_også_logge_input_parametre_til_sporingslogg_ved_permit() throws Exception {
+        final Auditlogger auditlogger = mockAuditLogger();
+        final AbacAuditlogger abacAuditlogger = new AbacAuditlogger(auditlogger);
+
+        var method = RestClass.class.getMethod("behandlingIdIn", BehandlingIdDto.class);
+        var appRessursData = AppRessursData.builder().leggTilAktørId(aktør1.aktørId()).build();
+        var beskyttetRessursAttributter = getBeskyttetRessursAttributter(method,
+            BeskyttetRessursInterceptor.finnAbacDataAttributter(method, new Object[]{behandlingIdDto}));
+
+        abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
+
+        assertGotPattern(auditlogger,
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ flexString2=1234 flexString2Label=Behandling request=/foo/behandling_id_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+    }
+
+    @Test
+    void auditlog_skal_ikke_logge_parametre_som_går_til_pdp_til_sporingslogg_ved_permit_når_det_er_konfigurert_unntak_i_annotering() throws Exception {
+        final Auditlogger auditlogger = mock(Auditlogger.class);
+        final AbacAuditlogger abacAuditlogger = new AbacAuditlogger(auditlogger);
+
+        var method = RestClass.class.getMethod("utenSporingslogg", BehandlingIdDto.class);
+        var appRessursData = AppRessursData.builder().leggTilAktørId(aktør1.aktørId()).build();
+        var beskyttetRessursAttributter = getBeskyttetRessursAttributter(method,
+            BeskyttetRessursInterceptor.finnAbacDataAttributter(method, new Object[]{behandlingIdDto}));
+
+        abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
+
+        verify(auditlogger, never()).logg(Mockito.any());
+    }
+
+    @Test
+    void auditlog_skal_logge_parametre_som_går_til_pdp_til_sporingslogg_ved_deny() throws Exception {
+        final Auditlogger auditlogger = mockAuditLogger();
+        final AbacAuditlogger abacAuditlogger = new AbacAuditlogger(auditlogger);
+
+        var method = RestClass.class.getMethod("aktoerIn", AktørDto.class);
+        var appRessursData = AppRessursData.builder().leggTilAktørId(aktør1.aktørId()).build();
+        var beskyttetRessursAttributter = getBeskyttetRessursAttributter(method,
+            BeskyttetRessursInterceptor.finnAbacDataAttributter(method, new Object[]{aktør1}));
+
+        abacAuditlogger.loggUtfall(AbacResultat.AVSLÅTT_KODE_6, beskyttetRessursAttributter, appRessursData);
+
+        assertGotPattern(auditlogger,
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|WARN|act=create duid=00000000000 end=__NUMBERS__ request=/foo/aktoer_in requestContext=pip.tjeneste.kan.kun.kalles.av.pdp.servicebruker suid=A000000");
+    }
+
+
+    private void assertGotPattern(final Auditlogger auditlogger, String expected) {
+        verify(auditlogger).logg(auditdataCaptor.capture());
+        final String actual = auditdataCaptor.getValue().toString();
+        assertThat(actual).matches(toAuditdataPattern(expected));
+    }
+
+    private static Auditlogger mockAuditLogger() {
+        final Auditlogger auditlogger = mock(Auditlogger.class);
+        when(auditlogger.getDefaultVendor()).thenReturn("felles");
+        when(auditlogger.getDefaultProduct()).thenReturn("felles-test");
+        return auditlogger;
+    }
+
+    private BeskyttetRessursAttributter getBeskyttetRessursAttributter(Method method, AbacDataAttributter dataAttributter) {
+        var beskyttetRessurs = method.getAnnotation(BeskyttetRessurs.class);
+
+        return BeskyttetRessursAttributter.builder()
+            .medBrukerId("A000000")
+            .medBrukerOid(UUID.randomUUID())
+            .medIdentType(IdentType.InternBruker)
+            .medAnsattGrupper(Set.of())
+            .medToken(Token.withOidcToken(BeskyttetRessursInterceptorTest.DUMMY_OPENID_TOKEN))
+            .medActionType(beskyttetRessurs.actionType())
+            .medAvailabilityType(beskyttetRessurs.availabilityType())
+            .medResourceType(beskyttetRessurs.resourceType())
+            .medSporingslogg(beskyttetRessurs.sporingslogg())
+            .medPepId("local-app")
+            .medServicePath(ActionUthenter.action(RestClass.class, method))
+            .medDataAttributter(dataAttributter)
+            .build();
+
+    }
+
+    private static String toAuditdataPattern(String s) {
+        return Pattern.quote(s).replaceAll("__NUMBERS__", unquoteInReplacement("[0-9]*"));
+    }
+
+    private static String unquoteInReplacement(String s) {
+        return "\\\\E" + s + "\\\\Q";
+    }
+
+    @Path("foo")
+    static class RestClass {
+
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP)
+        @Path("aktoer_in")
+        public void aktoerIn(@SuppressWarnings("unused") AktørDto param) {
+            // Test
+        }
+
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP)
+        @Path("behandling_id_in")
+        public void behandlingIdIn(@SuppressWarnings("unused") BehandlingIdDto param) {
+            // Test
+        }
+
+        @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.PIP, sporingslogg = false)
+        @Path("uten_sporingslogg")
+        public void utenSporingslogg(@SuppressWarnings("unused") BehandlingIdDto param) {
+            // Test
+        }
+
+    }
+
+    private record AktørDto(String aktørId) implements AbacDto {
+
+        @Override
+        public AbacDataAttributter abacAttributter() {
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.AKTØR_ID, aktørId);
+        }
+    }
+
+    private record BehandlingIdDto(Long id) implements AbacDto {
+
+        @Override
+        public AbacDataAttributter abacAttributter() {
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.BEHANDLING_ID, id);
+        }
+    }
+
+}

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/PepImplTest.java
@@ -43,6 +43,8 @@ class PepImplTest {
     @Mock
     private TokenProvider tokenProvider;
     @Mock
+    private AbacAuditlogger abacAuditlogger;
+    @Mock
     private PopulasjonKlient popKlientMock;
     @Mock
     private AnsattGruppeKlient gruppeKlientMock;
@@ -61,7 +63,7 @@ class PepImplTest {
 
     @BeforeEach
     void setUp() {
-        this.pep = new PepImpl(popKlientMock, gruppeKlientMock, pdpRequestBuilder);
+        this.pep = new PepImpl(abacAuditlogger, popKlientMock, gruppeKlientMock, pdpRequestBuilder);
     }
 
     @Test
@@ -71,7 +73,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isFalse();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -84,7 +86,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isFalse();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -98,7 +100,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isTrue();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -113,7 +115,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isFalse();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -128,7 +130,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isFalse();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -144,7 +146,7 @@ class PepImplTest {
 
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(AppRessursData.builder().build());
 
-        Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        var permit = pep.vurderTilgang(attributter);
         assertThat(permit.fikkTilgang()).isTrue();
         verifyNoInteractions(gruppeKlientMock);
         verifyNoInteractions(popKlientMock);
@@ -159,7 +161,7 @@ class PepImplTest {
         when(pdpRequestBuilder.lagAppRessursData(any())).thenReturn(appressursData);
         when(popKlientMock.vurderTilgangInternBruker(any(), any(), any())).thenReturn(Tilgangsvurdering.godkjenn());
 
-        @SuppressWarnings("unused") Tilgangsbeslutning permit = pep.vurderTilgang(attributter);
+        @SuppressWarnings("unused") var permit = pep.vurderTilgang(attributter);
         verifyNoInteractions(gruppeKlientMock);
         verify(popKlientMock).vurderTilgangInternBruker(attributter.getBrukerOid(), Set.of(), appressursData.getAktørIdSet());
     }


### PR DESCRIPTION
Flytter AbacAuditlogger fra BeskyttetRessursInterceptor til PepImpl pga k9tilbake.
Dette siden AbacAuditlogger tar med ResourceType.verdi() som må kunne mappes til K9-verdier
Lagt til og omstrukturert en del tester