### PR TITLE
TFP-5430 deserialiser oppgavetype til enum

### DIFF
--- a/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgave.java
+++ b/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgave.java
@@ -1,8 +1,8 @@
 package no.nav.vedtak.felles.integrasjon.oppgave.v1;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Oppgave(Long id,
@@ -12,7 +12,7 @@ public record Oppgave(Long id,
                       String aktoerId,
                       String tema,
                       String behandlingstema,
-                      String oppgavetype,
+                      Oppgavetype oppgavetype,
                       String behandlingstype,
                       Integer versjon,
                       String tildeltEnhetsnr,

--- a/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgavetype.java
+++ b/integrasjon/oppgave-rest-klient/src/main/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/Oppgavetype.java
@@ -1,9 +1,11 @@
 package no.nav.vedtak.felles.integrasjon.oppgave.v1;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Oppgavetype {
 
+    @JsonEnumDefaultValue UKJENT("UKJENT"),
     JOURNALFØRING("JFR"),
     VURDER_KONSEKVENS_YTELSE("VUR_KONS_YTE"),
     VURDER_DOKUMENT("VUR"),

--- a/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/AbstractOppgaveKlientTest.java
+++ b/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/AbstractOppgaveKlientTest.java
@@ -1,6 +1,5 @@
 package no.nav.vedtak.felles.integrasjon.oppgave.v1;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -33,7 +32,7 @@ class AbstractOppgaveKlientTest {
         oppgaver = new TestOppgave(restKlient);
     }
 
-    private static final String json = """
+    private static final String JSON_SER = """
         {
           "id": 357736794,
           "tildeltEnhetsnr":"1234",
@@ -61,7 +60,7 @@ class AbstractOppgaveKlientTest {
     void skal_returnere_dokumentoversikt_fagsak() {
         var captor = ArgumentCaptor.forClass(RestRequest.class);
 
-        when(restKlient.send(any(RestRequest.class), eq(Oppgave.class))).thenReturn(DefaultJsonMapper.fromJson(json, Oppgave.class));
+        when(restKlient.send(any(RestRequest.class), eq(Oppgave.class))).thenReturn(DefaultJsonMapper.fromJson(JSON_SER, Oppgave.class));
         when(restKlient.sendExpectConflict(captor.capture(), eq(String.class))).thenReturn("test");
 
         oppgaver.reserverOppgave("1", "testSbh");

--- a/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/OppgaveRestTest.java
+++ b/integrasjon/oppgave-rest-klient/src/test/java/no/nav/vedtak/felles/integrasjon/oppgave/v1/OppgaveRestTest.java
@@ -8,7 +8,7 @@ import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 class OppgaveRestTest {
 
-    private static final String json = """
+    private static final String JSON_SER = """
         {
           "id": 357736794,
           "tildeltEnhetsnr":"1234",
@@ -32,10 +32,34 @@ class OppgaveRestTest {
         """;
 
     @Test
-    void test_response() throws Exception {
-        var deserialized = DefaultJsonMapper.fromJson(json, Oppgave.class);
+    void test_response() {
+        var deserialized = DefaultJsonMapper.fromJson(JSON_SER, Oppgave.class);
         assertThat(deserialized).isNotNull();
         assertThat(deserialized.tildeltEnhetsnr()).isEqualTo("1234");
-        assertThat(deserialized.oppgavetype()).isEqualTo(Oppgavetype.BEHANDLE_SAK.getKode());
+        assertThat(deserialized.oppgavetype()).isEqualTo(Oppgavetype.BEHANDLE_SAK);
+    }
+
+    @Test
+    void test_response_ukjent_oppgave_type() {
+        var deserialized = DefaultJsonMapper.fromJson(JSON_SER.replace("BEH_SAK", "EN_VILL_EN"), Oppgave.class);
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.tildeltEnhetsnr()).isEqualTo("1234");
+        assertThat(deserialized.oppgavetype()).isEqualTo(Oppgavetype.UKJENT);
+    }
+
+    @Test
+    void test_response_vurder_dok() {
+        var deserialized = DefaultJsonMapper.fromJson(JSON_SER.replace("BEH_SAK", "VUR"), Oppgave.class);
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.tildeltEnhetsnr()).isEqualTo("1234");
+        assertThat(deserialized.oppgavetype()).isEqualTo(Oppgavetype.VURDER_DOKUMENT);
+    }
+
+    @Test
+    void test_response_vurder_konsekvens() {
+        var deserialized = DefaultJsonMapper.fromJson(JSON_SER.replace("BEH_SAK", "VUR_KONS_YTE"), Oppgave.class);
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.tildeltEnhetsnr()).isEqualTo("1234");
+        assertThat(deserialized.oppgavetype()).isEqualTo(Oppgavetype.VURDER_KONSEKVENS_YTELSE);
     }
 }


### PR DESCRIPTION
Gjør det lettere bruke oppgave med sjekk på oppgavetype - slipper mappe String til Oppgavetype selv
Innfører en default UKJENT-verdi. 