### PR TITLE
TFP-5972 Takle saksnummer som eneste parameter

### DIFF
--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAuditlogger.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/AbacAuditlogger.java
@@ -12,9 +12,7 @@ import static no.nav.vedtak.log.audit.CefFields.forSaksnummer;
 import static no.nav.vedtak.log.audit.EventClassId.AUDIT_ACCESS;
 import static no.nav.vedtak.log.audit.EventClassId.AUDIT_CREATE;
 import static no.nav.vedtak.log.audit.EventClassId.AUDIT_UPDATE;
-import static no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType.BEHANDLING_ID;
 import static no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType.BEHANDLING_UUID;
-import static no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType.FAGSAK_ID;
 import static no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType.SAKSNUMMER;
 
 import java.util.HashSet;
@@ -110,9 +108,9 @@ public class AbacAuditlogger {
             fields.add(new CefField(USER_ID, beskyttetRessursAttributter.getBrukerId()));
         }
 
-        getOneOfNew(beskyttetRessursAttributter.getDataAttributter(), SAKSNUMMER, FAGSAK_ID).ifPresent(fagsak -> fields.addAll(forSaksnummer(fagsak)));
+        getOneOfNew(beskyttetRessursAttributter.getDataAttributter(), SAKSNUMMER).ifPresent(fagsak -> fields.addAll(forSaksnummer(fagsak)));
 
-        getOneOfNew(beskyttetRessursAttributter.getDataAttributter(), BEHANDLING_UUID, BEHANDLING_ID).ifPresent(behandling -> fields.addAll(forBehandling(behandling)));
+        getOneOfNew(beskyttetRessursAttributter.getDataAttributter(), BEHANDLING_UUID).ifPresent(behandling -> fields.addAll(forBehandling(behandling)));
 
         return Set.copyOf(fields);
     }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/PepImpl.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/PepImpl.java
@@ -114,7 +114,7 @@ public class PepImpl implements Pep {
             }
         }
         // Vurdering av populasjonstilgang
-        if (appRessursData.getFødselsnumre().isEmpty() && appRessursData.getAktørIdSet().isEmpty()) {
+        if (appRessursData.getFødselsnumre().isEmpty() && appRessursData.getAktørIdSet().isEmpty() && appRessursData.getSaksnummer() == null) {
             // Ikke noe å sjekke for populasjonstilgang
             return Tilgangsvurdering.godkjenn();
         }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/StandardAbacAttributtType.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/StandardAbacAttributtType.java
@@ -14,13 +14,6 @@ public enum StandardAbacAttributtType implements AbacAttributtType {
     AKTØR_ID,
 
     /**
-     * Interne referanser som ikke bør eksponeres utenfor applikasjonen.
-     */
-    FAGSAK_ID,
-    BEHANDLING_ID,
-    AKSJONSPUNKT_KODE,
-
-    /**
      * Eksternt anvendbare referanser - saksnummer, unik UUID for Behandling.
      */
     SAKSNUMMER,

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacAuditLoggerTest.java
@@ -32,7 +32,7 @@ import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 class AbacAuditLoggerTest {
 
     private final AktørDto aktør1 = new AktørDto("00000000000");
-    private final BehandlingIdDto behandlingIdDto = new BehandlingIdDto(1234L);
+    private final BehandlingIdDto behandlingIdDto = new BehandlingIdDto(UUID.randomUUID());
 
     private final ArgumentCaptor<Auditdata> auditdataCaptor = ArgumentCaptor.forClass(Auditdata.class);
 
@@ -64,7 +64,7 @@ class AbacAuditLoggerTest {
         abacAuditlogger.loggUtfall(AbacResultat.GODKJENT, beskyttetRessursAttributter, appRessursData);
 
         assertGotPattern(auditlogger,
-            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ flexString2=1234 flexString2Label=Behandling request=/foo/behandling_id_in requestContext=no.nav.abac.attributter.foreldrepenger.fagsak suid=A000000");
+            "CEF:0|felles|felles-test|1.0|audit:create|ABAC Sporingslogg|INFO|act=create duid=00000000000 end=__NUMBERS__ flexString2=__HEX__ flexString2Label=Behandling request=/foo/behandling_id_in requestContext=no.nav.abac.attributter.foreldrepenger.fagsak suid=A000000");
     }
 
     @Test
@@ -132,7 +132,9 @@ class AbacAuditLoggerTest {
     }
 
     private static String toAuditdataPattern(String s) {
-        return Pattern.quote(s).replaceAll("__NUMBERS__", unquoteInReplacement("[0-9]*"));
+        return Pattern.quote(s)
+            .replaceAll("__NUMBERS__", unquoteInReplacement("[0-9]*"))
+            .replaceAll("__HEX__", unquoteInReplacement("[0-9a-f-]*"));
     }
 
     private static String unquoteInReplacement(String s) {
@@ -170,11 +172,11 @@ class AbacAuditLoggerTest {
         }
     }
 
-    private record BehandlingIdDto(Long id) implements AbacDto {
+    private record BehandlingIdDto(UUID id) implements AbacDto {
 
         @Override
         public AbacDataAttributter abacAttributter() {
-            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.BEHANDLING_ID, id);
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.BEHANDLING_UUID, id);
         }
     }
 

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacDataAttributterTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/AbacDataAttributterTest.java
@@ -1,11 +1,12 @@
 package no.nav.vedtak.sikkerhet.abac;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class AbacDataAttributterTest {
 
@@ -62,7 +63,7 @@ class AbacDataAttributterTest {
 
     @Test
     void leggTilEnCollection() {
-        var attributtType = StandardAbacAttributtType.AKSJONSPUNKT_KODE;
+        var attributtType = StandardAbacAttributtType.JOURNALPOST_ID;
 
         attributter.leggTil(attributtType, "Test");
         attributter.leggTil(attributtType, List.of("Test1", "Test2", "Test3"));
@@ -74,7 +75,7 @@ class AbacDataAttributterTest {
 
     @Test
     void leggTilEnAnnenAttributeType() {
-        var attributtType = StandardAbacAttributtType.AKSJONSPUNKT_KODE;
+        var attributtType = StandardAbacAttributtType.JOURNALPOST_ID;
 
         attributter.leggTil(attributtType, "Test");
 

--- a/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/internal/BeskyttetRessursInterceptorTest.java
+++ b/felles/abac/src/test/java/no/nav/vedtak/sikkerhet/abac/internal/BeskyttetRessursInterceptorTest.java
@@ -40,7 +40,7 @@ class BeskyttetRessursInterceptorTest {
     private final RestClass tjeneste = new RestClass();
 
     private final AktørDto aktør1 = new AktørDto("00000000000");
-    private final BehandlingIdDto behandlingIdDto = new BehandlingIdDto(1234L);
+    private final BehandlingIdDto behandlingIdDto = new BehandlingIdDto(UUID.randomUUID());
 
     private static final String BRUKER_IDENT = "A000000";
     private static final UUID BRUKER_OID = UUID.randomUUID();
@@ -161,11 +161,11 @@ class BeskyttetRessursInterceptorTest {
         }
     }
 
-    private record BehandlingIdDto(Long id) implements AbacDto {
+    private record BehandlingIdDto(UUID id) implements AbacDto {
 
         @Override
         public AbacDataAttributter abacAttributter() {
-            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.BEHANDLING_ID, id);
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.BEHANDLING_UUID, id);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
     <artifactId>felles-root</artifactId>
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>3.6.6</version>
+                <version>3.6.7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Dekker tilfellet der man kun sender saksnummer til fptilgang
Dessuten rydding i attributter (behandlingId, fagsakId ikke i bruk)