### PR TITLE
TFP-5972 sett logkontekst for systembruker

### DIFF
--- a/felles/abac-kontekst/src/main/java/no/nav/vedtak/sikkerhet/populasjon/TilgangKlient.java
+++ b/felles/abac-kontekst/src/main/java/no/nav/vedtak/sikkerhet/populasjon/TilgangKlient.java
@@ -75,16 +75,16 @@ public class TilgangKlient implements AnsattGruppeKlient, PopulasjonKlient {
     private record UidGruppeDto(@NotNull UUID uid, @Valid @NotNull Set<AnsattGruppe> grupper) { }
 
     public record PopulasjonInternRequest(@NotNull UUID ansattOid,
-                                          @Valid Set<String> identer,
+                                          @NotNull @Valid Set<String> identer,
                                           @Valid String saksnummer,
                                           @Valid UUID behandling) { }
 
     public record PopulasjonEksternRequest(@NotNull String subjectPersonIdent,
-                                           @Valid Set<String> identer,
-                                           @Valid Integer aldersgrense) { }
+                                           @NotNull @Valid Set<String> identer,
+                                           @Valid int aldersgrense) { }
 
-    public record TilgangsvurderingRespons(TilgangResultat tilgangResultat,
-                                           @NotNull String årsak,
+    public record TilgangsvurderingRespons(@NotNull TilgangResultat tilgangResultat,
+                                           String årsak,
                                            String auditIdent) { }
 
     private Tilgangsvurdering mapTilgangsvurdering(TilgangsvurderingRespons tilgangsvurdering) {

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/PdpRequestBuilder.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/PdpRequestBuilder.java
@@ -14,12 +14,13 @@ public interface PdpRequestBuilder {
 
     AppRessursData lagAppRessursData(AbacDataAttributter dataAttributter);
 
+    // Kalles primært for å sette log-context for systembruker
     // Trenger egentlig bare sette BEHANDLING_STATUS + FAGSAK_STATUS i tilfelle FAGSAK / UPDATE for skrivetilgangs-sjekk
     default AppRessursData lagAppRessursDataForSystembruker(AbacDataAttributter dataAttributter) {
         return lagAppRessursData(dataAttributter);
     }
 
-
+    // TODO: Evaluer behov for disse ifm inntektsmelding og selvbetjening. De er ikke i bruk i de klassiske applikasjonene.
     default boolean skalVurdereTilgangLokalt(BeskyttetRessursAttributter beskyttetRessursAttributter, AppRessursData appRessursData) {
         return false;
     }

--- a/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/SystemressursPolicies.java
+++ b/felles/abac/src/main/java/no/nav/vedtak/sikkerhet/abac/policy/SystemressursPolicies.java
@@ -54,12 +54,6 @@ public class SystemressursPolicies {
         return Tilgangsvurdering.godkjenn();
     }
 
-    public static boolean trengerAppRessursData(BeskyttetRessursAttributter beskyttetRessursAttributter) {
-        // se i relasjon til skriveBeskyttet
-        return ActionType.UPDATE.equals(beskyttetRessursAttributter.getActionType())
-            && ResourceType.FAGSAK.equals(beskyttetRessursAttributter.getResourceType());
-    }
-
     public static boolean riktigClusterNamespacePreAuth(String consumerId, AvailabilityType availabilityType) {
         if (consumerId == null || !PRE_AUTHORIZED.contains(consumerId)) {
             return false;


### PR DESCRIPTION
Det har vært betinget kall til pdprequest for systembruker. Dermed har ikke log-kontekst blitt satt.