### PR TITLE
TFP-5972 samle tilgangklienter dto+paths

### DIFF
--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/AbstractAnsattInfoKlient.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/AbstractAnsattInfoKlient.java
@@ -1,0 +1,55 @@
+package no.nav.vedtak.felles.integrasjon.ansatt;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.sikkerhet.kontekst.AnsattGruppe;
+
+public abstract class AbstractAnsattInfoKlient {
+
+    private final RestClient restClient;
+    private final RestConfig restConfig;
+    private final URI grupperMedlemUri;
+    private final URI grupperFilterUri;
+    private final URI ansattIdentUri;
+    private final URI ansattOidUri;
+
+
+    public AbstractAnsattInfoKlient() {
+        this.restClient = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        this.ansattIdentUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/ansatt/ansatt-ident").build();
+        this.ansattOidUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/ansatt/ansatt-oid").build();
+        this.grupperMedlemUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/ansatt/grupper-medlem").build();
+        this.grupperFilterUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/ansatt/grupper-filter").build();
+    }
+
+    protected AnsattInfoDto.Respons hentAnsattInfoForIdent(String ident) {
+        var request = RestRequest.newPOSTJson(new AnsattInfoDto.IdentRequest(ident), ansattIdentUri, restConfig);
+        return restClient.send(request, AnsattInfoDto.Respons.class);
+    }
+
+    protected AnsattInfoDto.Respons hentAnsattInfoForOid(UUID saksbehandler) {
+        var request = RestRequest.newPOSTJson(new AnsattInfoDto.OidRequest(saksbehandler), ansattOidUri, restConfig);
+        return restClient.send(request, AnsattInfoDto.Respons.class);
+    }
+
+    protected Set<AnsattGruppe> alleGrupper(UUID saksbehandler) {
+        var request = RestRequest.newPOSTJson(new GrupperDto.MedlemRequest(saksbehandler), grupperMedlemUri, restConfig);
+        return restClient.sendReturnOptional(request, GrupperDto.Respons.class).map(GrupperDto.Respons::grupper).orElseGet(Set::of);
+    }
+
+    protected Set<AnsattGruppe> filtrerGrupper(UUID saksbehandler, List<AnsattGruppe> grupper) {
+        var request = RestRequest.newPOSTJson(new GrupperDto.FilterRequest(saksbehandler, new HashSet<>(grupper)), grupperFilterUri, restConfig);
+        return restClient.sendReturnOptional(request, GrupperDto.Respons.class).map(GrupperDto.Respons::grupper).orElseGet(Set::of);
+    }
+
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/AnsattInfoDto.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/AnsattInfoDto.java
@@ -1,0 +1,23 @@
+package no.nav.vedtak.felles.integrasjon.ansatt;
+
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class AnsattInfoDto {
+
+    private AnsattInfoDto() {
+    }
+
+    // Finne ansattinfo basert på ansatt-ident
+    public record IdentRequest(@NotNull @Pattern(regexp = "^[a-zA-Z]\\d{6}$") String ansattIdent) { }
+
+    // Hente ansattinfo basert på Entra OID for ansatt
+    public record OidRequest(@NotNull @Valid UUID ansattOid) { }
+
+    // Ansattinfo
+    public record Respons(@NotNull UUID ansattOid, @NotNull String ansattIdent, @NotNull String navn, String ansattVedEnhetId) {}
+
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/GrupperDto.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ansatt/GrupperDto.java
@@ -1,0 +1,25 @@
+package no.nav.vedtak.felles.integrasjon.ansatt;
+
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.vedtak.sikkerhet.kontekst.AnsattGruppe;
+
+public class GrupperDto {
+
+    private GrupperDto() {
+    }
+
+    // Request får å hente alle grupper den ansatte er medlem av
+    public record MedlemRequest(@NotNull @Valid UUID ansattOid) { }
+
+    // Request får å sjekke om angitt ansatt er medlem av angitte grupper
+    public record FilterRequest(@NotNull @Valid UUID ansattOid, @NotNull @Valid Set<AnsattGruppe> grupper) { }
+
+    // Respons med hvilke grupper den ansatte er medlem av
+    public record Respons(@NotNull Set<AnsattGruppe> grupper) { }
+
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/AbstractTilgangKlient.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/AbstractTilgangKlient.java
@@ -1,0 +1,57 @@
+package no.nav.vedtak.felles.integrasjon.populasjon;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import no.nav.vedtak.felles.integrasjon.ansatt.GrupperDto;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.sikkerhet.kontekst.AnsattGruppe;
+
+
+public abstract class AbstractTilgangKlient {
+
+    private final URI ansattGruppeUri;
+    private final URI internBrukerUri;
+    private final URI eksternBrukerUri;
+    private final RestClient klient;
+    private final RestConfig restConfig;
+
+    protected AbstractTilgangKlient() {
+        this.klient = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        this.ansattGruppeUri = UriBuilder.fromUri(restConfig.fpContextPath())
+            .path("/api/ansatt/grupper-filter")
+            .build();
+        this.internBrukerUri = UriBuilder.fromUri(restConfig.fpContextPath())
+            .path("/api/populasjon/internbruker")
+            .build();
+        this.eksternBrukerUri = UriBuilder.fromUri(restConfig.fpContextPath())
+            .path("/api/populasjon/eksternbruker")
+            .build();
+    }
+
+    protected Set<AnsattGruppe> vurderGrupper(UUID ansattOid, Set<AnsattGruppe> påkrevdeGrupper) {
+        var request = new GrupperDto.FilterRequest(ansattOid, påkrevdeGrupper);
+        var rrequest = RestRequest.newPOSTJson(request, ansattGruppeUri, restConfig).timeout(Duration.ofSeconds(3));
+        return klient.sendReturnOptional(rrequest, GrupperDto.Respons.class).map(GrupperDto.Respons::grupper).orElseGet(Set::of);
+    }
+
+    protected PopulasjonDto.Respons vurderInternBruker(UUID ansattOid, Set<String> identer, String saksnummer, UUID behandling) {
+        var request = new PopulasjonDto.InternRequest(ansattOid, identer, saksnummer, behandling);
+        var rrequest = RestRequest.newPOSTJson(request, internBrukerUri, restConfig).timeout(Duration.ofSeconds(3));
+        return klient.send(rrequest, PopulasjonDto.Respons.class);
+    }
+
+    protected PopulasjonDto.Respons vurderEksternBruker(String subjectPersonIdent, Set<String> identer, int aldersgrense) {
+        var request = new PopulasjonDto.EksternRequest(subjectPersonIdent, identer, aldersgrense);
+        var rrequest = RestRequest.newPOSTJson(request, eksternBrukerUri, restConfig).timeout(Duration.ofSeconds(3));
+        return klient.send(rrequest, PopulasjonDto.Respons.class);
+    }
+
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/PopulasjonDto.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/PopulasjonDto.java
@@ -1,0 +1,29 @@
+package no.nav.vedtak.felles.integrasjon.populasjon;
+
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public class PopulasjonDto {
+
+    private PopulasjonDto() {
+    }
+
+    // For å om den ansatte har tilgang til personer basert på identer, saksnummer og behandling
+    public record InternRequest(@NotNull UUID ansattOid,
+                                @NotNull @Valid Set<String> identer,
+                                @Valid String saksnummer,
+                                @Valid UUID behandling) { }
+
+    // For å om innlogget borger har tilgang til å lese/endre basert på identer og alder
+    public record EksternRequest(@NotNull String subjectPersonIdent,
+                                 @NotNull @Valid Set<String> identer,
+                                 @Valid int aldersgrense) { }
+
+    // Godkjent eller avslått tilgang med evt avslagsårsak. Dessuten ident til bruk i auditlogging
+    public record Respons(@NotNull PopulasjonTilgangResultat tilgangResultat,
+                          String årsak,
+                          String auditIdent) { }
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/PopulasjonTilgangResultat.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/PopulasjonTilgangResultat.java
@@ -1,0 +1,13 @@
+package no.nav.vedtak.felles.integrasjon.populasjon;
+
+public enum PopulasjonTilgangResultat {
+    GODKJENT,
+    AVSLÅTT_KODE_7,
+    AVSLÅTT_KODE_6,
+    AVSLÅTT_EGEN_ANSATT,
+    AVSLÅTT_ANNEN_ÅRSAK;
+
+    public boolean fikkTilgang() {
+        return this == GODKJENT;
+    }
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ruting/RutingDto.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/ruting/RutingDto.java
@@ -1,0 +1,21 @@
+package no.nav.vedtak.felles.integrasjon.ruting;
+
+import java.util.Set;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public class RutingDto {
+
+    private RutingDto() {
+    }
+
+    // For å sjekke rutingegenskaper basert på identer
+    public record IdenterRequest(@Valid Set<String> identer) { }
+
+    // For å sjekke rutingegenskaper basert på saksnummer
+    public record SakRequest(@Valid @NotNull String saksnummer) { }
+
+    // Rutingegenkaper for identer eller sak
+    public record Respons(Set<RutingResultat> resultater) { }
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/sak/AbstractInvaliderSakKlient.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/sak/AbstractInvaliderSakKlient.java
@@ -1,0 +1,30 @@
+package no.nav.vedtak.felles.integrasjon.sak;
+
+import java.net.URI;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+
+
+public abstract class AbstractInvaliderSakKlient {
+
+    private final RestClient restClient;
+    private final RestConfig restConfig;
+    private final URI invaliderUri;
+
+    protected AbstractInvaliderSakKlient() {
+        this.restClient = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        this.invaliderUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/populasjon/invalidersak").build();
+    }
+
+    protected void invaliderSak(String saksnummer) {
+        var payload = new InvaliderSakRequest(saksnummer);
+        var request = RestRequest.newPOSTJson(payload, invaliderUri, restConfig);
+        restClient.sendReturnOptional(request, String.class);
+    }
+
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/sak/InvaliderSakRequest.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/sak/InvaliderSakRequest.java
@@ -1,0 +1,7 @@
+package no.nav.vedtak.felles.integrasjon.sak;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record InvaliderSakRequest(@NotNull @Valid String saksnummer) {
+}

--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/tilgangfilter/FilterDto.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/tilgangfilter/FilterDto.java
@@ -1,0 +1,21 @@
+package no.nav.vedtak.felles.integrasjon.tilgangfilter;
+
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+public class FilterDto {
+
+    private FilterDto() {
+    }
+
+    // For å sjekke hvilke saker den ansatte har tilgang til basert på saksnummer
+    public record SaksnummerRequest(@NotNull UUID ansattOid, Set<String> saker) { }
+
+    // For å sjekke hvilke identer den ansatte har tilgang til basert på identer
+    public record IdenterRequest(@NotNull UUID ansattOid, Set<String> identer) { }
+
+    // Hvilke av sakene/identene i request som den ansatte har tilgang til
+    public record Respons(Set<String> harTilgang) { }
+}


### PR DESCRIPTION
Samle alle kall til FpTilgang slik at paths og dtos ligger ett sted + kan brukes i fptilgang.
Legger opp til å forenkle kall til fptilgang til kun AAD/CC - ikke OBO for å hente ansattinfo som nå.
Sak, Los, Fordel vil extende og bruke klientene
Tilgang vil bruke dtos herfra.

Først må tilgang prodsettes.