### PR TITLE
chore: Feil URI-path for ene gruppesjekken

### DIFF
--- a/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/AbstractTilgangKlient.java
+++ b/integrasjon/tilgang-klient/src/main/java/no/nav/vedtak/felles/integrasjon/populasjon/AbstractTilgangKlient.java
@@ -26,7 +26,7 @@ public abstract class AbstractTilgangKlient {
         this.klient = RestClient.client();
         this.restConfig = RestConfig.forClient(this.getClass());
         this.ansattGruppeUri = UriBuilder.fromUri(restConfig.fpContextPath())
-            .path("/api/ansatt/grupper-filter")
+            .path("/api/ansattinfo/grupper-filter")
             .build();
         this.internBrukerUri = UriBuilder.fromUri(restConfig.fpContextPath())
             .path("/api/populasjon/internbruker")


### PR DESCRIPTION
Forglemmelse ifm standardisering av paths til info om ansatte og grupper. 
Kun synlig i ett tilfelle i tilgangskontroll (nøkkeltall til avdelingsleder i LOS).