### PR TITLE
Fritekst-annotering til bruk i Dtos og Valideringstester

### DIFF
--- a/felles/util/src/main/java/no/nav/vedtak/util/Fritekst.java
+++ b/felles/util/src/main/java/no/nav/vedtak/util/Fritekst.java
@@ -1,0 +1,12 @@
+package no.nav.vedtak.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface Fritekst {
+}


### PR DESCRIPTION
Det er en jakt på spøkelser å finne regexp for alle unicode-tegn i rene fritekst-felt.
Denne annoteringen gjør ingenting, men kan brukes sammen med @Valid og i tester som sjekker at alle Dtos er annotert med @Valid. Da kan man strukturert relaxe sjekken for String slik det er gjort noen steder.
Typisk angis den i VALIDERINGSALTERNATIVER for String.class: List.of(Fritekst.class, Size.class), List.of(Fritekst.class))
Tilsvarende er gjort i ft-beregning for en OppgittOpptjening/begrunnelseEndring som er uten validering i abakus.

Fpsak har gjort dette med en FritekstDto - som er unntatt fra validering. 