### PR TITLE
chore: sett kontekst i Kafka consumertråder

### DIFF
--- a/felles/kontekst/pom.xml
+++ b/felles/kontekst/pom.xml
@@ -19,10 +19,6 @@
             <groupId>no.nav.foreldrepenger.felles</groupId>
             <artifactId>felles-konfig</artifactId>
         </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger.felles</groupId>
-            <artifactId>felles-log</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProvider.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/AnsattGruppeProvider.java
@@ -12,14 +12,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.konfig.Environment;
 
 public class AnsattGruppeProvider {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AnsattGruppeProvider.class);
     private static final Environment ENV = Environment.current();
     private static final String SUFFIX = ".properties";
 
@@ -112,14 +108,12 @@ public class AnsattGruppeProvider {
         String navn = AnsattGruppeProvider.class.getSimpleName().toLowerCase() + infix + SUFFIX;
         try (var is = AnsattGruppeProvider.class.getResourceAsStream(navn)) {
             if (is != null) {
-                LOG.info("Laster groups fra {}", navn);
                 p.load(is);
                 return p;
             }
         } catch (IOException e) {
-            LOG.info("Propertyfil {} ikke lesbar", navn);
+            // Do nothing. Vurdere å gjør obligatorisk kaste Ex videre her og nedenfor
         }
-        LOG.info("Propertyfil {} ikke funnet", navn);
         return p;
     }
 

--- a/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/KontekstHolder.java
+++ b/felles/kontekst/src/main/java/no/nav/vedtak/sikkerhet/kontekst/KontekstHolder.java
@@ -1,11 +1,7 @@
 package no.nav.vedtak.sikkerhet.kontekst;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class KontekstHolder {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KontekstHolder.class);
     private static final BasisKontekst INGEN = BasisKontekst.tomKontekst();
 
     private static final ThreadLocal<Kontekst> KONTEKST = ThreadLocal.withInitial(() -> INGEN);
@@ -26,19 +22,12 @@ public class KontekstHolder {
         if (kontekst == null || !kontekst.harKontekst()) {
             throw new IllegalArgumentException("Bruk fjernKontekst");
         }
-        if (harKontekst()) {
-            var eksisterende = KONTEKST.get();
-            LOG.info("FPFELLES KONTEKST allerede satt type {} for {} ny {} for {}", eksisterende.getContext(), eksisterende.getUid(),
-                kontekst.getContext(), kontekst.getUid(), new Exception("Stracktrace/setKontekst"));
-        }
         KONTEKST.set(kontekst);
     }
 
     public static void fjernKontekst() {
         if (harKontekst()) {
             KONTEKST.remove();
-        } else {
-            LOG.info("FPFELLES KONTEKST allerede fjernet", new Exception("Stracktracegenerator/fjernKontekst"));
         }
     }
 

--- a/integrasjon/kafka-properties/pom.xml
+++ b/integrasjon/kafka-properties/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-kontekst</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>

--- a/integrasjon/kafka-properties/src/main/java/no/nav/vedtak/felles/integrasjon/kafka/KafkaConsumerManager.java
+++ b/integrasjon/kafka-properties/src/main/java/no/nav/vedtak/felles/integrasjon/kafka/KafkaConsumerManager.java
@@ -7,6 +7,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import no.nav.vedtak.sikkerhet.kontekst.BasisKontekst;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 public class KafkaConsumerManager<K,V> {
@@ -73,7 +76,7 @@ public class KafkaConsumerManager<K,V> {
 
         private final KafkaMessageHandler<K, V> handler;
         private KafkaConsumer<K, V> consumer;
-        private final AtomicInteger running = new AtomicInteger(ConsumerState.UNINITIALIZED.hashCode());
+        private final AtomicInteger conState = new AtomicInteger(ConsumerState.UNINITIALIZED.hashCode());
 
         public KafkaConsumerLoop(KafkaMessageHandler<K,V> handler) {
             this.handler = handler;
@@ -87,29 +90,33 @@ public class KafkaConsumerManager<K,V> {
         @Override
         public void run() {
             try(var key = handler.keyDeserializer().get(); var value = handler.valueDeserializer().get()) {
+                KontekstHolder.setKontekst(BasisKontekst.forProsesstaskUtenSystembruker());
                 var props = KafkaProperties.forConsumerGenericValue(handler.groupId(), key, value, handler.autoOffsetReset().orElse(null));
                 consumer = new KafkaConsumer<>(props, key, value);
                 consumer.subscribe(List.of(handler.topic()));
-                running.set(RUNNING);
-                while (running.get() == RUNNING) {
-                    var records = consumer.poll(POLL_TIMEOUT);
-                    for (var record : records) {
-                        handler.handleRecord(record.key(), record.value());
+                conState.set(RUNNING);
+                while (conState.get() == RUNNING) {
+                    var krecords = consumer.poll(POLL_TIMEOUT);
+                    for (var krecord : krecords) {
+                        handler.handleRecord(krecord.key(), krecord.value());
                     }
                 }
             } finally {
                 if (consumer != null) {
                     consumer.close(CLOSE_TIMEOUT);
                 }
-                running.set(ConsumerState.STOPPED.hashCode());
+                conState.set(ConsumerState.STOPPED.hashCode());
+                if (KontekstHolder.harKontekst()) {
+                    KontekstHolder.fjernKontekst();
+                }
             }
         }
 
         public void shutdown() {
-            if (running.get() == RUNNING) {
-                running.set(ConsumerState.STOPPING.hashCode());
+            if (conState.get() == RUNNING) {
+                conState.set(ConsumerState.STOPPING.hashCode());
             } else {
-                running.set(ConsumerState.STOPPED.hashCode());
+                conState.set(ConsumerState.STOPPED.hashCode());
             }
             // Kan vurdere consumer.wakeup() + håndtere WakeupException ovenfor - men har utelatt til fordel for en tilstand og polling med kort timeout
         }
@@ -119,11 +126,11 @@ public class KafkaConsumerManager<K,V> {
         }
 
         public boolean isRunning() {
-            return running.get() == RUNNING;
+            return conState.get() == RUNNING;
         }
 
         public boolean isStopped() {
-            return running.get() == ConsumerState.STOPPED.hashCode();
+            return conState.get() == ConsumerState.STOPPED.hashCode();
         }
     }
 }


### PR DESCRIPTION
Nylig oppdaget problem: Kafka-håndterer kaller metode som nå kan finne på å kalle kalkulus, klient er ADAPTIVE.
Setter derfor samme type kontekst som for prosesstasks og utenfor konsument-loopen i tråden.
Fjerner noen logg-deps som ikke har vært logget siste måneder.
Kan vurdere å gjøre AnsattGruppe-prop.filene obligatorisk (de skal være bundlet) og kaste exception når de ikke kan leses.