### PR TITLE
Manuell commit i KafkaConsumerManager for å sikre ingen tapte meldinger (at-least-once)

### DIFF
--- a/integrasjon/kafka-properties/src/main/java/no/nav/vedtak/felles/integrasjon/kafka/KafkaProperties.java
+++ b/integrasjon/kafka-properties/src/main/java/no/nav/vedtak/felles/integrasjon/kafka/KafkaProperties.java
@@ -46,6 +46,7 @@ public class KafkaProperties {
         props.put(CommonClientConfigs.GROUP_ID_CONFIG, groupId);
         props.put(CommonClientConfigs.CLIENT_ID_CONFIG, generateClientId());
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getAivenConfig(AivenProperty.KAFKA_BROKERS));
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         Optional.ofNullable(offsetReset).ifPresent(or -> props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, or.toString()));
 
         putSecurity(props);


### PR DESCRIPTION
Legger ut forslaget på fix for tap av meldinger ved exception fra messageHandler. Det er ikke behov for endringer i appene som bruker denne.

Skrur av automatisk commit i KafkaConsumerManager. Håndterer commits via map som oppdateres per partisjon. Ikke ambisjon om exactly-once, men unngå tapte meldinger ved commit i consumer.close() ved autocommit. Dette kan øke takten på async commit, ettersom commit her gjøres etter hver prosesserte batch vs ved poll når tid siden siste commit overstiger commit interval. Dersom behov for redusert takt må man ha lokal mekanisme for det tilsvarende commit interval-funksjonaliteten.