### PR TITLE
TFP-6939: kopier builder i HttpRequest.request() for å unngå dupliserte header-verdier

### DIFF
--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
@@ -1,5 +1,8 @@
 package no.nav.vedtak.klient.http;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -19,6 +22,8 @@ import java.util.function.Supplier;
  */
 public class HttpClientRequest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HttpClientRequest.class);
+
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
 
     private final HttpRequest.Builder builder;
@@ -26,6 +31,7 @@ public class HttpClientRequest {
     private final Map<String, Supplier<String>> headers;
     private final Map<Supplier<String>, String> dependentHeaders;
     private final List<Consumer<HttpRequest>> validators;
+    private boolean built;
 
     private HttpClientRequest() {
         this(HttpRequest.newBuilder(), null);
@@ -36,6 +42,7 @@ public class HttpClientRequest {
         this.headers = headers != null ? new HashMap<>(headers) : new HashMap<>();
         this.dependentHeaders = new HashMap<>();
         this.validators = new ArrayList<>(List.of(HttpClientRequest::validateTimeout));
+        this.built = false;
     }
 
     public HttpClientRequest timeout(Duration timeout) {
@@ -55,6 +62,14 @@ public class HttpClientRequest {
     }
 
     HttpRequest request() {
+        if (built) {
+            try {
+               throw new IllegalStateException("HttpRequest already built");
+            } catch (IllegalStateException e) {
+                LOG.warn("HttpRequest already built", e);
+            }
+        }
+        this.built = true;
         var requestBuilder = builder.copy();
         requestBuilder.timeout(Optional.ofNullable(timeout).orElse(DEFAULT_TIMEOUT));
         headers.forEach((key, value) -> requestBuilder.header(key, value.get()));

--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
@@ -63,11 +63,8 @@ public class HttpClientRequest {
 
     HttpRequest request() {
         if (built) {
-            try {
-               throw new IllegalStateException("HttpRequest already built");
-            } catch (IllegalStateException e) {
-                LOG.warn("HttpRequest already built", e);
-            }
+            // Logg forekomster - vil unngå gjenbruk av requests
+            LOG.warn("HttpRequest already built", new IllegalStateException("HttpRequest already built"));
         }
         this.built = true;
         var requestBuilder = builder.copy();

--- a/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
+++ b/felles/klient/src/main/java/no/nav/vedtak/klient/http/HttpClientRequest.java
@@ -55,10 +55,11 @@ public class HttpClientRequest {
     }
 
     HttpRequest request() {
-        builder.timeout(Optional.ofNullable(timeout).orElse(DEFAULT_TIMEOUT));
-        headers.forEach((key, value) -> builder.header(key, value.get()));
-        dependentHeaders.forEach((key, value) -> Optional.ofNullable(key.get()).ifPresent(v -> builder.header(value, v)));
-        var request = builder.build();
+        var requestBuilder = builder.copy();
+        requestBuilder.timeout(Optional.ofNullable(timeout).orElse(DEFAULT_TIMEOUT));
+        headers.forEach((key, value) -> requestBuilder.header(key, value.get()));
+        dependentHeaders.forEach((key, value) -> Optional.ofNullable(key.get()).ifPresent(v -> requestBuilder.header(value, v)));
+        var request = requestBuilder.build();
         validators.forEach(v -> v.accept(request));
         return request;
     }


### PR DESCRIPTION
Flere apper gjør en enkel retry ved å kalle klient.send(req) på nytt med samme request. Biblioteket delegerer til  en klasse som holder headere i en Map<String, List<String>>. Når man kaller request.header(key, value) erstatter den ikke foregående verdi men legger den heller til listen (dupliserte values). Ser 400 fra nginx i logger ved retry i disse appene. Har tidligere sett tilsvarende feil i tokensupport for Spring, med 400 fra nginx.

Ref https://nav-it.slack.com/archives/CEKQHNLLU/p1776328934058859