### PR TITLE
Chore: generalisere deserialize/typereference, ikke bare List

### DIFF
--- a/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJson3Mapper.java
+++ b/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJson3Mapper.java
@@ -57,9 +57,9 @@ public class DefaultJson3Mapper {
                     .withScalarConstructorVisibility(JsonAutoDetect.Visibility.ANY));
     }
 
-    public static <T> List<T> fromJson(String json, TypeReference<List<T>> typeReference) {
+    public static <T> T fromJson(String json, TypeReference<T> typeReference) {
         try {
-            return MAPPER.readValue(json, typeReference);
+            return MAPPER.readerFor(typeReference).readValue(json);
         } catch (JacksonException e) {
             throw deserializationException(e);
         }

--- a/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJsonMapper.java
+++ b/felles/mapper/src/main/java/no/nav/vedtak/mapper/json/DefaultJsonMapper.java
@@ -62,9 +62,9 @@ public class DefaultJsonMapper {
             .build();
     }
 
-    public static <T> List<T> fromJson(String json, TypeReference<List<T>> typeReference) {
+    public static <T> T fromJson(String json, TypeReference<T> typeReference) {
         try {
-            return MAPPER.readValue(json, typeReference);
+            return MAPPER.readerFor(typeReference).readValue(json);
         } catch (IOException e) {
             throw deserializationException(e);
         }


### PR DESCRIPTION
Brukes bare i fpautotest. Dette med binding til List gjør denne mindre anvendelig til andre formål.