### PR TITLE
Teknisk: samle oppsett av JettyDevServer til felles klasse

### DIFF
--- a/felles/server/src/main/java/no/nav/vedtak/server/localdev/LocalDevProperties.java
+++ b/felles/server/src/main/java/no/nav/vedtak/server/localdev/LocalDevProperties.java
@@ -1,9 +1,9 @@
-package no.nav.vedtak.felles.testutilities.server;
+package no.nav.vedtak.server.localdev;
 
 import no.nav.foreldrepenger.konfig.Environment;
 
 /**
- * Felles oppsett for JettyDevServer i IDE.
+ * Felles oppsett for JettyDevServer i IDE. Ikke bruk utenom JettyDevServer.
  */
 public final class LocalDevProperties {
 

--- a/felles/server/src/main/java/no/nav/vedtak/server/localdev/LocalDevProperties.java
+++ b/felles/server/src/main/java/no/nav/vedtak/server/localdev/LocalDevProperties.java
@@ -18,6 +18,9 @@ public final class LocalDevProperties {
      * Leser properties: keystore.relativ.path, truststore.relativ.path, vtp.ssl.passord, user.home.
      */
     public static void setPropertiesForLocalDev() {
+        if (!ENV.isLocal()) {
+            throw new IllegalStateException("LocalDevProperties skal kun brukes i lokal utvikling");
+        }
         var keystoreRelativPath = ENV.getProperty("keystore.relativ.path");
         var truststoreRelativPath = ENV.getProperty("truststore.relativ.path");
         var keystoreTruststorePassword = ENV.getProperty("vtp.ssl.passord");

--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/server/LocalDevProperties.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/server/LocalDevProperties.java
@@ -1,0 +1,35 @@
+package no.nav.vedtak.felles.testutilities.server;
+
+import no.nav.foreldrepenger.konfig.Environment;
+
+/**
+ * Felles oppsett for JettyDevServer i IDE.
+ */
+public final class LocalDevProperties {
+
+
+    private static final Environment ENV = Environment.current();
+
+    private LocalDevProperties() {
+    }
+
+    /**
+     * Konfigurerer SSL truststore/keystore og Kafka-credentials for lokal utvikling med JettyDevServer i IDE
+     * Leser properties: keystore.relativ.path, truststore.relativ.path, vtp.ssl.passord, user.home.
+     */
+    public static void setPropertiesForLocalDev() {
+        var keystoreRelativPath = ENV.getProperty("keystore.relativ.path");
+        var truststoreRelativPath = ENV.getProperty("truststore.relativ.path");
+        var keystoreTruststorePassword = ENV.getProperty("vtp.ssl.passord");
+        var absolutePathHome = ENV.getProperty("user.home", ".");
+        System.setProperty("javax.net.ssl.trustStore", absolutePathHome + truststoreRelativPath);
+        System.setProperty("javax.net.ssl.keyStore", absolutePathHome + keystoreRelativPath);
+        System.setProperty("javax.net.ssl.trustStorePassword", keystoreTruststorePassword);
+        System.setProperty("javax.net.ssl.keyStorePassword", keystoreTruststorePassword);
+        System.setProperty("javax.net.ssl.password", keystoreTruststorePassword);
+        System.setProperty("KAFKA_TRUSTSTORE_PATH", absolutePathHome + truststoreRelativPath);
+        System.setProperty("KAFKA_KEYSTORE_PATH", absolutePathHome + keystoreRelativPath);
+        System.setProperty("KAFKA_CREDSTORE_PASSWORD", keystoreTruststorePassword);
+    }
+
+}


### PR DESCRIPTION
Denne koden finnes i alle JettyDevServer - trengs for kjøring i IDE, men ikke under Docker/autotest