### PR TITLE
Chore: Skille Autentiseringsfilter og Rest-oppsett

### DIFF
--- a/felles/server/src/main/java/no/nav/vedtak/server/rest/FpRestJackson2Feature.java
+++ b/felles/server/src/main/java/no/nav/vedtak/server/rest/FpRestJackson2Feature.java
@@ -10,7 +10,6 @@ public class FpRestJackson2Feature implements Feature {
 
     @Override
     public boolean configure(final FeatureContext context) {
-        context.register(AuthenticationFilter.class);
         context.register(Jackson2RestFeature.class);
         context.register(ValidationExceptionMapper.class);
         context.register(GeneralRestExceptionMapper.class);

--- a/felles/server/src/main/java/no/nav/vedtak/server/rest/FpRestJackson3Feature.java
+++ b/felles/server/src/main/java/no/nav/vedtak/server/rest/FpRestJackson3Feature.java
@@ -10,7 +10,6 @@ public class FpRestJackson3Feature implements Feature {
 
     @Override
     public boolean configure(final FeatureContext context) {
-        context.register(AuthenticationFilter.class);
         context.register(Jackson3RestFeature.class);
         context.register(ValidationExceptionMapper.class);
         context.register(GeneralRestExceptionMapper.class);


### PR DESCRIPTION
Vil ta med denne endringen i denne runden. Min copilot fikser opp dette + fp-grunndata bruker vanlig oppsett.
Dette er for mer direkte navigering fram til Autentisering + planer om ScopedValue og ServletFilter
Det er en spenstig mulighet - java har en native HttpClient men også en brukbar motpart.