### PR TITLE
TFP-7017 samle felles db-relatert kode, unngå JNDI

### DIFF
--- a/felles/db/pom.xml
+++ b/felles/db/pom.xml
@@ -50,10 +50,21 @@
         <dependency>
              <groupId>io.micrometer</groupId>
              <artifactId>micrometer-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/EntityManagerProducer.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/EntityManagerProducer.java
@@ -2,14 +2,8 @@ package no.nav.vedtak.felles.jpa;
 
 import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.hibernate.SessionFactory;
-import org.hibernate.jpa.HibernateHints;
-import org.hibernate.stat.HibernateMetrics;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.RequestScoped;
@@ -19,7 +13,16 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.FlushModeType;
+
 import jakarta.persistence.Persistence;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.jpa.HibernateHints;
+import org.hibernate.orm.micrometer.HibernateMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.vedtak.felles.jpa.jdbc.DataSourceHolder;
 
 
 /**
@@ -30,24 +33,20 @@ import jakarta.persistence.Persistence;
 @ApplicationScoped
 public class EntityManagerProducer {
 
-    private static final String EM_NAME = "pu-default";
     private static final Logger LOG = LoggerFactory.getLogger(EntityManagerProducer.class);
-    /**
-     * registrerte {@link EntityManagerFactory}.
-     */
-    private static final Map<String, EntityManagerFactory> CACHE_FACTORIES = new ConcurrentHashMap<>();
+    private static EntityManagerFactory entityManagerFactory;
 
     @Produces
     @RequestScoped
     public EntityManager createEntityManager() {
-        return createNewEntityManager(EM_NAME);
+        return createNewEntityManager();
     }
 
-    private synchronized EntityManager createNewEntityManager(String key) {
-        if (!CACHE_FACTORIES.containsKey(key)) {
-            CACHE_FACTORIES.put(key, createEntityManager(key));
+    private synchronized EntityManager createNewEntityManager() {
+        if (entityManagerFactory == null) {
+            entityManagerFactory = getEntityManagerFactory();
         }
-        var emf = CACHE_FACTORIES.get(key);
+        var emf = entityManagerFactory;
         var em = emf.createEntityManager();
         initConfig(em, emf.getProperties());
         return em;
@@ -59,16 +58,20 @@ public class EntityManagerProducer {
      */
     private void initConfig(EntityManager em, Map<String, Object> props) {
         // regresson hibernate 4.5.6 - org.hibernate.flushMode er redefinert som
-        // QueryHint (ikke AvailableSettings) - blir ikke automatisk satt på
-        // EM.
+        // QueryHint (ikke AvailableSettings) - blir ikke automatisk satt på EM.
         em.setFlushMode(FlushModeType.valueOf((String) props.getOrDefault(HibernateHints.HINT_FLUSH_MODE, "COMMIT")));
     }
 
-    public EntityManagerFactory createEntityManager(String key) {
-        var emf = Persistence.createEntityManagerFactory(key);
-        LOG.info("Muliggjør hibernate monitorering, slås på med hibernate.generate_statistics=true i de enkeltes persistence.xml");
-        HibernateMetrics.monitor(globalRegistry, emf.unwrap(SessionFactory.class), EM_NAME);
-        return emf;
+    public static EntityManagerFactory getEntityManagerFactory() {
+        if (entityManagerFactory == null) {
+            Map<String, Object> props = new HashMap<>();
+            props.put("jakarta.persistence.nonJtaDataSource", DataSourceHolder.getDataSource());
+            var emf = Persistence.createEntityManagerFactory(NamingStandard.DEFAULT_PERSISTENCE_UNIT, props);
+            LOG.info("Muliggjør hibernate monitorering, slås på med hibernate.generate_statistics=true i de enkeltes persistence.xml");
+            HibernateMetrics.monitor(globalRegistry, emf.unwrap(SessionFactory.class), NamingStandard.DEFAULT_PERSISTENCE_UNIT);
+            entityManagerFactory = emf;
+        }
+        return entityManagerFactory;
     }
 
     public void dispose(@Disposes EntityManager mgr) {

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/NamingStandard.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/NamingStandard.java
@@ -1,0 +1,17 @@
+package no.nav.vedtak.felles.jpa;
+
+public class NamingStandard {
+
+    private NamingStandard() {
+    }
+
+    // Standard name in persistence xml
+    public static final String DEFAULT_PERSISTENCE_UNIT = "pu-default";
+
+    // Standard data source name, and paths to migrations
+    public static final String DEFAULT_DATA_SOURCE = "defaultDS";
+    public static final String DEFAULT_MIGRATION_ROOT = "/db/migration/";
+    public static final String DEFAULT_DS_MIGRATION_PATH = DEFAULT_MIGRATION_ROOT + DEFAULT_DATA_SOURCE;
+    public static final String DEFAULT_DS_MIGRATION_CLASSPATH = "classpath:" + DEFAULT_MIGRATION_ROOT + DEFAULT_DATA_SOURCE;
+
+}

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/flyway/FlywayUtil.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/flyway/FlywayUtil.java
@@ -1,0 +1,45 @@
+package no.nav.vedtak.felles.jpa.flyway;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import no.nav.vedtak.felles.jpa.jdbc.DatasourceUtil;
+
+public final class FlywayUtil {
+
+    private FlywayUtil() {
+    }
+
+    public static void migratePostgresGcp(DataSource ds, String location) {
+        flywayConfig(ds, location)
+            .load()
+            .migrate();
+    }
+
+    public static void migrateOracle(DataSource ds, String location) {
+        flywayConfig(ds, location)
+            .table("schema_version")
+            .load()
+            .migrate();
+    }
+
+    public static FluentConfiguration flywayConfig(DataSource dataSource, String location) {
+        return Flyway.configure().dataSource(dataSource).locations(location).baselineOnMigrate(true);
+    }
+
+    // DataSource used in a try/resources around migration. Not used elsewhere.
+    public static HikariDataSource createMigrationDataSource(String jdbcUrl, String username, String password) {
+        var hikariConfig = createMigrationDataSourceConfig(jdbcUrl, username, password);
+        return new HikariDataSource(hikariConfig);
+    }
+
+    public static HikariConfig createMigrationDataSourceConfig(String jdbcUrl, String username, String password) {
+        return DatasourceUtil.createDataSourceConfig(jdbcUrl, username, password, 3);
+    }
+
+}

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/flyway/FlywayUtil.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/flyway/FlywayUtil.java
@@ -15,13 +15,15 @@ public final class FlywayUtil {
     private FlywayUtil() {
     }
 
-    public static void migratePostgresGcp(DataSource ds, String location) {
+    // Standard migrering. Unntak: On-prem postgres med callback og Oracle med "schema-version"
+    public static void migrate(DataSource ds, String location) {
         flywayConfig(ds, location)
             .load()
             .migrate();
     }
 
-    public static void migrateOracle(DataSource ds, String location) {
+    // Må brukes fram til tabell schema_version (+constraint + 2 index) er renamed til flyway_schema_history
+    public static void migrateLegacyOracle(DataSource ds, String location) {
         flywayConfig(ds, location)
             .table("schema_version")
             .load()
@@ -32,7 +34,7 @@ public final class FlywayUtil {
         return Flyway.configure().dataSource(dataSource).locations(location).baselineOnMigrate(true);
     }
 
-    // DataSource used in a try/resources around migration. Not used elsewhere.
+    // Dedicated DataSource for use in a try/resources around migration. Not used elsewhere.
     public static HikariDataSource createMigrationDataSource(String jdbcUrl, String username, String password) {
         var hikariConfig = createMigrationDataSourceConfig(jdbcUrl, username, password);
         return new HikariDataSource(hikariConfig);

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/jdbc/DataSourceHolder.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/jdbc/DataSourceHolder.java
@@ -1,0 +1,31 @@
+package no.nav.vedtak.felles.jpa.jdbc;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+public class DataSourceHolder {
+
+    private static DataSource ds;
+
+    private DataSourceHolder() {
+    }
+
+    // Call this explicitly in your main method before launching Jetty/Weld
+    public static void initialize(DataSource localDataSource) {
+        ds = localDataSource;
+        if (ds instanceof HikariDataSource hds) {
+            Runtime.getRuntime().addShutdownHook(new Thread(hds::close));
+        }
+    }
+
+    public static DataSource getDataSource() {
+        if (ds == null) throw new IllegalStateException("DataSource not initialized.");
+        return ds;
+    }
+
+    public static boolean isInitialized() {
+        return ds != null;
+    }
+
+}

--- a/felles/db/src/main/java/no/nav/vedtak/felles/jpa/jdbc/DatasourceUtil.java
+++ b/felles/db/src/main/java/no/nav/vedtak/felles/jpa/jdbc/DatasourceUtil.java
@@ -1,0 +1,58 @@
+package no.nav.vedtak.felles.jpa.jdbc;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import io.micrometer.core.instrument.Metrics;
+
+public final class DatasourceUtil {
+
+    private DatasourceUtil() {
+    }
+
+    public static HikariDataSource postgresDataSource(String jdbcUrl, String username, String password, int maxPoolSize) {
+        var hikariConfig = postgresDataSourceConfig(jdbcUrl, username, password, maxPoolSize);
+        return new HikariDataSource(hikariConfig);
+    }
+
+    public static HikariConfig postgresDataSourceConfig(String jdbcUrl, String username, String password, int maxPoolSize) {
+        var config = createDataSourceConfig(jdbcUrl, username, password, maxPoolSize);
+        config.setMetricRegistry(Metrics.globalRegistry);
+
+        // optimaliserer inserts for postgres
+        var dsProperties = new Properties();
+        dsProperties.setProperty("reWriteBatchedInserts", "true");
+        dsProperties.setProperty("logServerErrorDetail", "false"); // skrur av batch exceptions som lekker statements i åpen logg
+        config.setDataSourceProperties(dsProperties);
+
+        return config;
+    }
+
+    public static HikariDataSource oracleDataSource(String jdbcUrl, String username, String password, int maxPoolSize) {
+        var config = createDataSourceConfig(jdbcUrl, username, password, maxPoolSize);
+        config.setMetricRegistry(Metrics.globalRegistry);
+
+        // Kan vurdere å ta inn disse to som Properties - samme metode som for postgres
+        // ("oracle.jdbc.implicitStatementCacheSize", "50"); // Gjerne litt over antall entiteter
+        // ("oracle.jdbc.defaultConnectionValidation", "LOCAL"); // LOCAL, SOCKET, NETWORK (default)
+
+        return new HikariDataSource(config);
+    }
+
+    public static HikariConfig createDataSourceConfig(String jdbcUrl, String username, String password, int maxPoolSize) {
+        var config = new HikariConfig();
+        config.setJdbcUrl(jdbcUrl);
+        Optional.ofNullable(username).ifPresent(config::setUsername);
+        Optional.ofNullable(password).ifPresent(config::setPassword);
+        config.setConnectionTimeout(2500);
+        config.setMaximumPoolSize(maxPoolSize);
+        config.setMinimumIdle(maxPoolSize / 2);
+        // Styres av EntityManager
+        config.setAutoCommit(false);
+        return config;
+    }
+
+}

--- a/felles/testutilities/pom.xml
+++ b/felles/testutilities/pom.xml
@@ -32,6 +32,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>compile</scope>

--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/MigrationUtil.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/MigrationUtil.java
@@ -1,0 +1,48 @@
+package no.nav.vedtak.felles.testutilities.db;
+
+import java.io.File;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import no.nav.vedtak.felles.jpa.flyway.FlywayUtil;
+import no.nav.vedtak.felles.jpa.jdbc.DatasourceUtil;
+
+public final class MigrationUtil {
+
+    private MigrationUtil() {
+    }
+
+    public static void migrateLocalBuildTest(DataSource ds, String scriptPath) {
+        var flyway = FlywayUtil.flywayConfig(ds, scriptPath)
+            .cleanDisabled(false)
+            .load();
+        try {
+            flyway.migrate();
+        } catch (Exception _) {
+            flyway.clean();
+            flyway.migrate();
+        }
+    }
+
+    public static HikariDataSource createLocalBuildTestDataSource(String jdbcUrl, String username, String password) {
+        var config = DatasourceUtil.createDataSourceConfig(jdbcUrl, username, password, 8);
+        return new HikariDataSource(config);
+    }
+
+    // Trengs ved multi-modul-prosjekt - traverserer opp til man finner stien
+    public static String getScriptLocation(String relativePath) {
+        var baseDir = new File(".").getAbsoluteFile();
+        var location = new File(baseDir, relativePath);
+        while (!location.exists()) {
+            baseDir = baseDir.getParentFile();
+            if (baseDir == null || !baseDir.isDirectory()) {
+                throw new IllegalArgumentException("Klarte ikke finne : " + baseDir);
+            }
+            location = new File(baseDir, relativePath);
+        }
+        return "filesystem:" + location.getPath();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-parent-lib</artifactId>
-        <version>5.3.4</version>
+        <version>5.3.5</version>
     </parent>
 
     <artifactId>felles-root</artifactId>


### PR DESCRIPTION
Samler og standardiserer en del database-relatert kode som ligger duplisert rundt i 13 repos
* Oppsett av DataSource (likt for enhetstester, litt ulikt oracle/postgres for deployment)
* Migrering
* Test-oppsett - likt på tvers av plattform
* Standardiserer navngivning. Unntak: noen har migrering under db/postgres/defaultDS, fp-sak har dvhDS i tillegg
* Legger opp til en DataSourceHolder - som fjerner behov for JNDI (Jetty-plus og EnvEntry)

Har testet lokalt med en miks av oracle og postgres-varianter