### PR TITLE
TFP-7043: legg til abstrakte db-strukturtester for PostgreSQL og Oracle

### DIFF
--- a/felles/testutilities/pom.xml
+++ b/felles/testutilities/pom.xml
@@ -46,5 +46,10 @@
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
 	</dependencies>
 </project>

--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractDbStrukturTest.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractDbStrukturTest.java
@@ -1,0 +1,25 @@
+package no.nav.vedtak.felles.testutilities.db;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Felles base for DB-strukturtester. */
+public abstract class AbstractDbStrukturTest extends EntityManagerAwareTest {
+
+    protected List<String> runSingleColumnQuery(String sql) {
+        return getEntityManager().createNativeQuery(sql, String.class).getResultStream().toList();
+    }
+
+    protected List<Object[]> runMultiColumnQuery(String sql) {
+        return getEntityManager().createNativeQuery(sql, Object[].class).getResultList();
+    }
+
+    protected String joinRows(List<Object[]> rows) {
+        return rows.stream()
+            .map(row -> Arrays.stream(row)
+                .map(col -> col instanceof Character c ? c.toString() : (String) col)
+                .collect(Collectors.joining(", ")))
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractOracleDbStrukturTest.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractOracleDbStrukturTest.java
@@ -1,0 +1,267 @@
+package no.nav.vedtak.felles.testutilities.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+/** Felles strukturtester for Oracle. */
+public abstract class AbstractOracleDbStrukturTest extends AbstractDbStrukturTest {
+
+    /** Schema-eier brukt i Oracle ALL_*-views. */
+    protected abstract String getOwner();
+
+    /**
+     * Tabellnavn-mønstre (LIKE-syntax) som ekskluderes fra alle sjekker.
+     * Eksempel: {@code List.of("%_MOCK", "HTE_%")}
+     */
+    protected List<String> ekskluderteTabellmønstre() {
+        return List.of();
+    }
+
+    /**
+     * Kolonnenavn (eksakt, upper-case) som ekskluderes fra kolonnesjekken.
+     * Eksempel: {@code List.of("LANDKODE")}
+     */
+    protected List<String> ekskluderteKolonner() {
+        return List.of();
+    }
+
+    /** Bygger AND upper(kolonneRef) NOT LIKE 'mønster' for hvert ekskludert tabellmønster. */
+    private String tabellFilter(String kolonneRef) {
+        return ekskluderteTabellmønstre().stream()
+            .map(m -> "  AND upper(" + kolonneRef + ") NOT LIKE '" + m.toUpperCase() + "'")
+            .collect(Collectors.joining("\n"));
+    }
+
+    /** Bygger AND upper(kolonneRef) NOT IN ('KOL1','KOL2',...) hvis listen ikke er tom. */
+    private String kolonneFilter(String kolonneRef) {
+        if (ekskluderteKolonner().isEmpty()) return "";
+        var verdier = ekskluderteKolonner().stream()
+            .map(k -> "'" + k.toUpperCase() + "'")
+            .collect(Collectors.joining(","));
+        return "  AND upper(" + kolonneRef + ") NOT IN (" + verdier + ")";
+    }
+
+    @Test
+    void sjekk_at_alle_tabeller_er_dokumentert() {
+        var sql = """
+            SELECT table_name FROM ALL_TAB_COMMENTS
+            WHERE (comments IS NULL OR comments IN ('','MISSING COLUMN COMMENT'))
+              AND owner = sys_context('userenv','current_schema')
+              AND upper(table_name) NOT LIKE '%SCHEMA_%'
+            """ + tabellFilter("table_name");
+        assertThat(runSingleColumnQuery(sql)).isEmpty();
+    }
+
+    @Test
+    void sjekk_at_alle_relevante_kolonner_er_dokumentert() {
+        var sql = """
+            SELECT t.owner||'.'||t.table_name||'.'||t.column_name
+            FROM ALL_COL_COMMENTS t
+            WHERE (t.comments IS NULL OR t.comments = '')
+              AND t.owner = sys_context('userenv','current_schema')
+              AND upper(t.table_name) NOT LIKE '%SCHEMA_%'
+              AND NOT EXISTS (
+                SELECT 1 FROM ALL_CONSTRAINTS a, ALL_CONS_COLUMNS b
+                WHERE a.table_name = b.table_name
+                  AND b.table_name = t.table_name
+                  AND a.constraint_name = b.constraint_name
+                  AND b.column_name = t.column_name
+                  AND constraint_type IN ('P','R')
+                  AND a.owner = t.owner
+                  AND b.owner = a.owner)
+              AND upper(t.column_name) NOT IN
+                ('OPPRETTET_TID','ENDRET_TID','OPPRETTET_AV','ENDRET_AV',
+                 'VERSJON','BESKRIVELSE','NAVN','FOM','TOM','AKTIV')
+            """ + kolonneFilter("t.column_name") + "\n" + tabellFilter("t.table_name") + """
+
+            ORDER BY t.table_name, t.column_name
+            """;
+        var avvik = runSingleColumnQuery(sql).stream().map(r -> "\n" + r).toList();
+        assertThat(avvik)
+            .withFailMessage("Mangler dokumentasjon for %s kolonner. %s%n%nGå over SQL-skriptene og dokumenter tabellene.",
+                avvik.size(), avvik)
+            .isEmpty();
+    }
+
+    @Test
+    void sjekk_at_alle_FK_kolonner_har_fornuftig_indekser() {
+        var sql = """
+            SELECT UC.TABLE_NAME, UC.CONSTRAINT_NAME,
+                   LISTAGG(DCC.COLUMN_NAME, ',') WITHIN GROUP (ORDER BY DCC.POSITION)
+            FROM ALL_CONSTRAINTS UC
+            INNER JOIN ALL_CONS_COLUMNS DCC
+              ON DCC.CONSTRAINT_NAME = UC.CONSTRAINT_NAME AND DCC.OWNER = UC.OWNER
+            WHERE UC.CONSTRAINT_TYPE = 'R'
+              AND upper(UC.OWNER) = upper(:owner)
+            """ + tabellFilter("UC.TABLE_NAME") + """
+
+              AND EXISTS (
+                SELECT UCC.POSITION, UCC.COLUMN_NAME
+                FROM ALL_CONS_COLUMNS UCC
+                WHERE UCC.CONSTRAINT_NAME = UC.CONSTRAINT_NAME AND UC.OWNER = UCC.OWNER
+                MINUS
+                SELECT UIC.COLUMN_POSITION, UIC.COLUMN_NAME
+                FROM ALL_IND_COLUMNS UIC
+                WHERE UIC.TABLE_NAME = UC.TABLE_NAME AND UIC.TABLE_OWNER = UC.OWNER
+              )
+            GROUP BY UC.TABLE_NAME, UC.CONSTRAINT_NAME
+            ORDER BY UC.TABLE_NAME
+            """;
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Kolonner som inngår i Foreign Keys skal ha indekser. Mangler indekser for %s foreign keys%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_ha_primary_key_i_hver_tabell_som_begynner_med_PK() {
+        var sql = """
+            SELECT table_name FROM all_tables at
+            WHERE table_name NOT IN (
+              SELECT ac.table_name FROM all_constraints ac
+              WHERE ac.constraint_type = 'P'
+                AND at.owner = ac.owner
+                AND ac.constraint_name LIKE 'PK_%')
+              AND upper(at.owner) = upper(:owner)
+              AND upper(at.table_name) NOT LIKE '%SCHEMA_%'
+            """ + tabellFilter("at.table_name");
+        var q = getEntityManager().createNativeQuery(sql, String.class);
+        q.setParameter("owner", getOwner());
+        List<String> avvik = q.getResultList();
+        assertThat(avvik)
+            .withFailMessage("Feil eller manglende primary key (skal hete 'PK_<tabell navn>'). Antall feil = %s%n%nTabell:%n%s",
+                avvik.size(), String.join("\n", avvik))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_ha_alle_foreign_keys_begynne_med_FK() {
+        var sql = """
+            SELECT ac.table_name, ac.constraint_name FROM all_constraints ac
+            WHERE ac.constraint_type = 'R'
+              AND upper(ac.owner) = upper(:owner)
+              AND constraint_name NOT LIKE 'FK_%'
+            """ + tabellFilter("ac.table_name");
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Feil eller manglende foreign key (skal hete 'FK_<tabell navn>_<løpenummer>'). Antall feil = %s%n%nTabell, Foreign Key%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_ha_korrekt_index_navn() {
+        var sql = """
+            SELECT table_name, index_name, column_name
+            FROM all_ind_columns
+            WHERE table_owner = upper(:owner)
+              AND index_name NOT LIKE 'PK_%'
+              AND index_name NOT LIKE 'IDX_%'
+              AND index_name NOT LIKE 'UIDX_%'
+              AND upper(table_name) NOT LIKE '%SCHEMA_%'
+              AND upper(table_name) NOT LIKE 'BIN$%'
+            """ + tabellFilter("table_name");
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Feil navngiving av index (PK_, UIDX_, IDX_). Antall feil = %s%n%nTabell, Index, Kolonne%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_ha_samme_data_type_for_begge_sider_av_en_FK() {
+        var sql = """
+            SELECT TO_CHAR(T.TABLE_NAME), TO_CHAR(TCC.COLUMN_NAME),
+                   TO_CHAR(ATT.DATA_TYPE), TO_CHAR(ATT.CHAR_LENGTH), TO_CHAR(ATT.CHAR_USED),
+                   TO_CHAR(RCC.COLUMN_NAME),
+                   TO_CHAR(ATR.DATA_TYPE), TO_CHAR(ATR.CHAR_LENGTH), TO_CHAR(ATR.CHAR_USED)
+            FROM ALL_CONSTRAINTS T
+            INNER JOIN ALL_CONSTRAINTS R
+              ON R.OWNER = T.OWNER AND R.CONSTRAINT_NAME = T.R_CONSTRAINT_NAME
+            INNER JOIN ALL_CONS_COLUMNS TCC
+              ON TCC.TABLE_NAME = T.TABLE_NAME AND TCC.OWNER = T.OWNER
+             AND TCC.CONSTRAINT_NAME = T.CONSTRAINT_NAME
+            INNER JOIN ALL_CONS_COLUMNS RCC
+              ON RCC.TABLE_NAME = R.TABLE_NAME AND RCC.OWNER = R.OWNER
+             AND RCC.CONSTRAINT_NAME = R.CONSTRAINT_NAME
+            INNER JOIN ALL_TAB_COLS ATT
+              ON ATT.COLUMN_NAME = TCC.COLUMN_NAME AND ATT.OWNER = TCC.OWNER
+             AND ATT.TABLE_NAME = TCC.TABLE_NAME
+            INNER JOIN ALL_TAB_COLS ATR
+              ON ATR.COLUMN_NAME = RCC.COLUMN_NAME AND ATR.OWNER = RCC.OWNER
+             AND ATR.TABLE_NAME = RCC.TABLE_NAME
+            WHERE T.OWNER = upper(:owner)
+              AND T.CONSTRAINT_TYPE = 'R'
+              AND TCC.POSITION = RCC.POSITION
+              AND TCC.POSITION IS NOT NULL AND RCC.POSITION IS NOT NULL
+              AND ((ATT.DATA_TYPE != ATR.DATA_TYPE)
+                OR (ATT.CHAR_LENGTH != ATR.CHAR_LENGTH OR ATT.CHAR_USED != ATR.CHAR_USED)
+                OR (ATT.DATA_TYPE NOT LIKE '%CHAR%' AND ATT.DATA_LENGTH != ATR.DATA_LENGTH))
+            """ + tabellFilter("T.TABLE_NAME") + """
+
+            ORDER BY T.TABLE_NAME, TCC.COLUMN_NAME
+            """;
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Forskjellig datatype på FK-sider (husk VARCHAR2(100 CHAR)). Antall feil = %s%n%nTABELL, KOL_A, KOL_A_DATA_TYPE, KOL_A_CHAR_LENGTH, KOL_A_CHAR_USED, KOL_B, KOL_B_DATA_TYPE, KOL_B_CHAR_LENGTH, KOL_B_CHAR_USED%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_deklarere_VARCHAR2_kolonner_som_CHAR_ikke_BYTE_semantikk() {
+        var sql = """
+            SELECT TO_CHAR(TABLE_NAME), TO_CHAR(COLUMN_NAME),
+                   TO_CHAR(DATA_TYPE), TO_CHAR(CHAR_USED), TO_CHAR(CHAR_LENGTH)
+            FROM ALL_TAB_COLS
+            WHERE DATA_TYPE = 'VARCHAR2'
+              AND CHAR_USED != 'C'
+              AND upper(TABLE_NAME) NOT LIKE '%SCHEMA%'
+              AND CHAR_LENGTH > 1
+              AND OWNER = upper(:owner)
+            """ + tabellFilter("TABLE_NAME") + """
+
+            ORDER BY TABLE_NAME, COLUMN_NAME
+            """;
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Feil deklarasjon av VARCHAR2 (husk VARCHAR2(100 CHAR)). Antall feil = %s%n%nTABELL, KOLONNE, DATA_TYPE, CHAR_USED, CHAR_LENGTH%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    void skal_ikke_bruke_FLOAT_eller_DOUBLE() {
+        var sql = """
+            SELECT TO_CHAR(TABLE_NAME), TO_CHAR(COLUMN_NAME), TO_CHAR(DATA_TYPE)
+            FROM ALL_TAB_COLS
+            WHERE OWNER = upper(:owner)
+              AND DATA_TYPE IN ('FLOAT', 'DOUBLE')
+            """ + tabellFilter("TABLE_NAME") + """
+
+            ORDER BY TABLE_NAME, COLUMN_NAME
+            """;
+        var q = getEntityManager().createNativeQuery(sql, Object[].class);
+        q.setParameter("owner", getOwner());
+        List<Object[]> rows = q.getResultList();
+        assertThat(rows)
+            .withFailMessage("Feil bruk av datatype, skal ikke ha FLOAT eller DOUBLE (bruk NUMBER for alle desimaltall, spesielt der penger representeres). Antall feil = %s%n%nTabell, Kolonne, Datatype%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+}

--- a/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractPostgresDbStrukturTest.java
+++ b/felles/testutilities/src/main/java/no/nav/vedtak/felles/testutilities/db/AbstractPostgresDbStrukturTest.java
@@ -1,0 +1,242 @@
+package no.nav.vedtak.felles.testutilities.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Felles strukturtester for PostgreSQL. */
+public abstract class AbstractPostgresDbStrukturTest extends AbstractDbStrukturTest {
+
+    @Test
+    @DisplayName("Test at alle tabeller er kommentert.")
+    void sjekk_at_alle_tabeller_er_dokumentert() {
+        var sql = """
+            SELECT t.table_name
+            FROM information_schema.tables t
+            JOIN pg_class c ON t.table_name = c.relname
+            WHERE t.table_schema = current_schema
+              AND t.table_name NOT LIKE 'flyway_%'
+              AND t.table_name NOT LIKE 'prosess_task_partition_%'
+              AND obj_description(c.oid) IS NULL
+            """;
+        assertThat(runSingleColumnQuery(sql)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle kolonner er kommentert. Bortsett fra PK og FK kolonner.")
+    void sjekk_at_alle_relevante_kolonner_er_dokumentert() {
+        var sql = """
+            SELECT c.table_name||'.'||c.column_name
+            FROM pg_catalog.pg_statio_all_tables AS st
+              RIGHT JOIN pg_catalog.pg_description pgd ON pgd.objoid = st.relid
+              RIGHT JOIN information_schema.columns c
+                ON pgd.objsubid = c.ordinal_position
+               AND c.table_schema = st.schemaname
+               AND c.table_name = st.relname
+            WHERE c.table_schema = current_schema
+              AND upper(c.column_name) NOT IN
+                ('OPPRETTET_TID','ENDRET_TID','OPPRETTET_AV','ENDRET_AV',
+                 'VERSJON','BESKRIVELSE','NAVN','FOM','TOM','AKTIV')
+              AND c.table_name NOT LIKE 'flyway_%'
+              AND c.table_name NOT LIKE 'prosess_task_partition_%'
+              AND c.table_name NOT LIKE 'prosess_task'
+              AND pgd.description IS NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                  ON tc.constraint_name = kcu.constraint_name
+                 AND tc.table_schema = kcu.table_schema
+                WHERE constraint_type IN ('FOREIGN KEY','PRIMARY KEY')
+                  AND tc.table_schema = current_schema
+                  AND tc.table_name = c.table_name
+                  AND kcu.column_name = c.column_name
+              )
+            ORDER BY c.table_name, c.column_name
+            """;
+        var avvik = runSingleColumnQuery(sql).stream().map(r -> "\n" + r).toList();
+        assertThat(avvik)
+            .withFailMessage("Mangler dokumentasjon for %s kolonner. %s%n%nGå over SQL-skriptene og dokumenter tabellene.",
+                avvik.size(), avvik)
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle primary keys har navn med pk_ prefix.")
+    void skal_ha_primary_key_i_hver_tabell_som_begynner_med_PK() {
+        var sql = """
+            SELECT t.table_name
+            FROM information_schema.tables t
+            WHERE t.table_schema = current_schema
+              AND t.table_name NOT LIKE 'flyway_%'
+              AND t.table_name NOT LIKE 'prosess_task_partition_%'
+              AND t.table_name NOT IN (
+                SELECT c.table_name FROM information_schema.table_constraints c
+                WHERE c.constraint_type = 'PRIMARY KEY' AND c.constraint_name LIKE 'pk_%'
+              )
+            """;
+        var avvik = runSingleColumnQuery(sql);
+        assertThat(avvik)
+            .withFailMessage("Feil eller manglende primary key (skal hete 'pk_<tabell navn>'). Antall feil = %s%n%nTabell:%n%s",
+                avvik.size(), String.join("\n", avvik))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle foreign keys har navn med fk_ prefix.")
+    void skal_ha_alle_foreign_keys_begynne_med_FK() {
+        var sql = """
+            SELECT table_name, constraint_name
+            FROM information_schema.table_constraints
+            WHERE constraint_type = 'FOREIGN KEY'
+              AND table_schema = current_schema
+              AND constraint_name NOT LIKE 'fk_%'
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Feil eller manglende foreign key (skal hete 'fk_<tabell navn>_<løpenummer>'). Antall feil = %s%n%nTabell, Foreign Key%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at indekser har riktige prefix: pk_, uidx_, idx_, chk_")
+    void skal_ha_korrekt_index_navn() {
+        var sql = """
+            SELECT t.relname, i.relname, a.attname
+            FROM pg_class t, pg_class i, pg_index ix, pg_attribute a,
+                 information_schema.tables it
+            WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid
+              AND a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+              AND t.relkind = 'r' AND t.relname = it.table_name
+              AND it.table_schema = current_schema
+              AND it.table_name NOT LIKE 'flyway_%'
+              AND it.table_name NOT LIKE 'prosess_task_partition_%'
+              AND i.relname NOT LIKE 'pk_%'
+              AND i.relname NOT LIKE 'idx_%'
+              AND i.relname NOT LIKE 'uidx_%'
+              AND i.relname NOT LIKE 'chk_%'
+            ORDER BY t.relname, i.relname
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Feil navngiving av index (pk_, uidx_, idx_, chk_). Antall feil = %s%n%nTabell, Index, Kolonne%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle FK har like datatyper på begge sider.")
+    void skal_ha_samme_data_type_for_begge_sider_av_en_FK() {
+        var sql = """
+            SELECT t1.relname, cs1.column_name, cs1.data_type,
+                   cs1.character_maximum_length::text, cs1.character_octet_length::text,
+                   cs2.column_name, cs2.data_type,
+                   cs2.character_maximum_length::text, cs2.character_octet_length::text
+            FROM pg_class t1, pg_class t2,
+                 information_schema.columns cs1, information_schema.columns cs2,
+                 LATERAL (
+                   SELECT c.conrelid, unnest(c.conkey) AS conkeypos,
+                          c.confrelid, unnest(c.confkey) AS confkeypos
+                   FROM pg_constraint c WHERE c.contype = 'f'
+                 ) AS fk
+            WHERE fk.conrelid = t1.oid AND fk.confrelid = t2.oid
+              AND t1.relname = cs1.table_name AND t2.relname = cs2.table_name
+              AND fk.conkeypos = cs1.ordinal_position
+              AND fk.confkeypos = cs2.ordinal_position
+              AND cs1.table_schema = current_schema AND cs2.table_schema = current_schema
+              AND cs1.table_name NOT LIKE 'prosess_task_partition_%'
+              AND cs2.table_name NOT LIKE 'prosess_task_partition_%'
+              AND (cs1.data_type != cs2.data_type
+                OR cs1.character_maximum_length != cs2.character_maximum_length
+                OR cs1.character_octet_length != cs2.character_octet_length
+                OR cs1.numeric_precision != cs2.numeric_precision
+                OR cs1.numeric_precision_radix != cs2.numeric_precision_radix
+                OR cs1.numeric_scale != cs2.numeric_scale)
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Forskjellig datatype for kolonne på hver side av en FK. Antall feil = %s%n%nTABELL, KOL_A, KOL_A_DATA_TYPE, KOL_A_CHAR_LENGTH, KOL_A_CHAR_USED, KOL_B, KOL_B_DATA_TYPE, KOL_B_CHAR_LENGTH, KOL_B_CHAR_USED%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at real, float, double precision datatyper ikke brukes.")
+    void skal_ikke_bruke_FLOAT_REAL_eller_DOUBLEPRECISION() {
+        var sql = """
+            SELECT table_name, column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema = current_schema
+              AND data_type IN ('real','double precision','float')
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Feil bruk av datatype REAL/FLOAT/DOUBLE PRECISION (bruk NUMERIC). Antall feil = %s%n%nTabell, Kolonne, Datatype%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle FK-kolonner har en indeks.")
+    void sjekk_at_alle_FK_kolonner_har_fornuftig_indekser() {
+        var sql = """
+            SELECT uc.table_name, uc.constraint_name,
+                   STRING_AGG(dcc.column_name, ',' ORDER BY dcc.ordinal_position)
+            FROM information_schema.table_constraints uc
+            JOIN information_schema.key_column_usage dcc
+              ON dcc.constraint_name = uc.constraint_name
+             AND dcc.table_schema = uc.table_schema
+            WHERE uc.constraint_type = 'FOREIGN KEY'
+              AND uc.table_schema = current_schema
+              AND EXISTS (
+                SELECT ucc.column_name
+                FROM information_schema.key_column_usage ucc
+                WHERE ucc.constraint_name = uc.constraint_name
+                  AND ucc.table_schema = uc.table_schema
+                EXCEPT
+                SELECT a.attname
+                FROM pg_catalog.pg_index ix
+                JOIN pg_catalog.pg_class t ON t.oid = ix.indrelid
+                JOIN pg_catalog.pg_class i ON i.oid = ix.indexrelid
+                JOIN pg_catalog.pg_attribute a ON a.attnum = ANY(ix.indkey) AND a.attrelid = t.oid
+                WHERE t.relkind = 'r' AND t.relname = uc.table_name
+              )
+            GROUP BY uc.table_name, uc.constraint_name
+            ORDER BY uc.table_name
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Kolonner som inngår i Foreign Keys skal ha indekser. Mangler indekser for %s foreign keys%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test at alle unike indekser har uidx_ prefix.")
+    void sjekk_at_alle_unike_indekser_starter_med_uidx_prefiks() {
+        var sql = """
+            SELECT tbl.relname, idx.relname
+            FROM pg_index pgi
+            JOIN pg_class idx ON idx.oid = pgi.indexrelid
+            JOIN pg_namespace insp ON insp.oid = idx.relnamespace
+            JOIN pg_class tbl ON tbl.oid = pgi.indrelid
+            JOIN pg_namespace tnsp ON tnsp.oid = tbl.relnamespace
+            WHERE pgi.indisunique
+              AND tbl.relname NOT LIKE 'flyway_%'
+              AND tbl.relname NOT LIKE 'prosess_task_partition_%'
+              AND idx.relname NOT LIKE 'pk_%'
+              AND idx.relname NOT LIKE 'uidx_%'
+              AND tnsp.nspname = current_schema
+            ORDER BY tbl.relname
+            """;
+        var rows = runMultiColumnQuery(sql);
+        assertThat(rows)
+            .withFailMessage("Unike indekser skal starte med uidx_. Antall feil = %s%n%nTabell, Index%n%s",
+                rows.size(), joinRows(rows))
+            .isEmpty();
+    }
+}


### PR DESCRIPTION
### Slik tas det i bruk
**PostgreSQL** (fp-soknad, fp-mottak, fp-kalkulus, fp-abakus, fp-inntektsmelding, fp-formidling, fp-oversikt, fp-los):

```
@ExtendWith(JpaExtension.class)
class SjekkDbStrukturTest extends AbstractPostgresDbStrukturTest {}
```

**Oracle med JPA** (fpoppdrag, fp-risk):
```
@ExtendWith(JpaExtension.class)
class SjekkDbStrukturTest extends AbstractOracleDbStrukturTest {
    @Override
    protected String getOwner() {
        return JpaExtension.DEFAULT_TEST_DB_SCHEMA_NAME;
    }
}
```

**Oracle uten eget schema-navn** (fp-sak, fptilbake):
```
@ExtendWith(JpaExtension.class)
class SjekkDbStrukturTest extends AbstractOracleDbStrukturTest {
    @Override
    protected String getOwner() {
        return NamingStandard.DEFAULT_DATA_SOURCE;
    }
}
```

### Bakgrunn
Alle 12 fp-repos hadde identisk eller tilnærmet identisk `SjekkDbStrukturTest` (~350 linjer hver). Endringen reduserer hver test til 3–18 linjer og sikrer at forbedringer i SQL-ene kommer alle repos til gode automatisk.
`getOwner()` er abstrakt i Oracle-varianten (ikke en default) for å forhindre at testen stilles mot feil schema og alltid passerer.