### PR TITLE
fix: marker sikkerloggEnabled som volatile for korrekt verdi på tvers av tråder

### DIFF
--- a/felles/server/src/main/java/no/nav/vedtak/server/rest/RestSecureLogFeature.java
+++ b/felles/server/src/main/java/no/nav/vedtak/server/rest/RestSecureLogFeature.java
@@ -11,7 +11,7 @@ public class RestSecureLogFeature implements Feature {
 
     // Kan evt vurdere en variabel for logger-navn. Må da registrere object/ctor framfor klasse.
     private static final Logger SECURE_LOG = LoggerFactory.getLogger("secureLogger");
-    private static boolean sikkerloggEnabled = false;
+    private static volatile boolean sikkerloggEnabled = false;
 
     public static boolean erSikkerloggEnabled() {
         return sikkerloggEnabled;


### PR DESCRIPTION
Jeg ser at det mangler minst ett logginnslag til secureLogs for valideringsfeil i fp-inntektsmelding. Ai peker på at man behøver volatile keyword for å sikre at alle tråder skal se non-stale verdi. For meg virker dette å være sannsynlig årsak til manglende logginnslag i dette tilfellet. 

Har ikke forsøkt sammenstille ordinær logg og secureLogs for å se etter flere tilfeller.

Aktuelt logginnslag omtales her: https://nav-it.slack.com/archives/CEKQHNLLU/p1782985641083199?thread_ts=1782978370.827709&cid=CEKQHNLLU